### PR TITLE
chore(website): add header prose/code font selectors with Atkinson Hy…

### DIFF
--- a/typescript/packages/website/astro.config.mjs
+++ b/typescript/packages/website/astro.config.mjs
@@ -28,11 +28,12 @@ export default defineConfig({
       },
       head: [
         {
-          // Apply the stored palette before first paint (Jord is the
-          // attribute-less default; only Fjord needs marking).
+          // Apply the stored palette and font choices before first paint (the
+          // defaults — Jord palette, STIX prose, JetBrains code — are
+          // attribute-less; only a non-default choice needs marking).
           tag: 'script',
           content:
-            "try{var p=localStorage.getItem('var-palette');if(p==='fjord'||p==='ild'||p==='fjeld')document.documentElement.dataset.palette=p}catch(e){}",
+            "try{var d=document.documentElement.dataset;var p=localStorage.getItem('var-palette');if(p==='fjord'||p==='ild'||p==='fjeld')d.palette=p;if(localStorage.getItem('var-font-prose')==='atkinson')d.fontProse='atkinson';if(localStorage.getItem('var-font-code')==='atkinson')d.fontCode='atkinson'}catch(e){}",
         },
       ],
       social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/oselvar/var' }],

--- a/typescript/packages/website/package.json
+++ b/typescript/packages/website/package.json
@@ -21,6 +21,8 @@
     "@codemirror/lsp-client": "^6.2.5",
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
+    "@fontsource/atkinson-hyperlegible": "^5.2.8",
+    "@fontsource/atkinson-hyperlegible-mono": "^5.2.10",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/stix-two-text": "^5.2.8",
     "@lezer/highlight": "^1.2.3",

--- a/typescript/packages/website/src/components/ThemeSelect.astro
+++ b/typescript/packages/website/src/components/ThemeSelect.astro
@@ -1,11 +1,17 @@
 ---
 /**
- * Starlight `ThemeSelect` override: prepends a palette selector (Jord — the
- * default earthy palette in custom.css — or Fjord, the teal palette in
- * themes/fjord.css) next to the built-in dark/light/auto select. The chosen
- * palette lives in `data-palette` on <html> and persists in localStorage
- * (`var-palette`); an inline head script in astro.config.mjs re-applies it
- * before first paint.
+ * Starlight `ThemeSelect` override: prepends the site's custom header controls
+ * next to the built-in dark/light/auto select.
+ *
+ * - Palette selector (Jord — the default earthy palette in custom.css — or
+ *   Fjord/Ild/Fjeld). The choice lives in `data-palette` on <html>.
+ * - Prose font selector (STIX Two Text or Atkinson Hyperlegible) → `data-font-prose`.
+ * - Code font selector (JetBrains Mono or Atkinson Hyperlegible Mono) → `data-font-code`.
+ *
+ * Each choice persists in localStorage (`var-palette` / `var-font-prose` /
+ * `var-font-code`); an inline head script in astro.config.mjs re-applies all
+ * three before first paint. The font attributes drive --sl-font / --sl-font-mono
+ * via the override rules in custom.css; headings stay on Norse regardless.
  */
 import Select from '@astrojs/starlight/components/Select.astro'
 import Default from '@astrojs/starlight/components/ThemeSelect.astro'
@@ -24,6 +30,28 @@ import Default from '@astrojs/starlight/components/ThemeSelect.astro'
     width="6.25em"
   />
 </var-palette-select>
+<var-font-select data-font-kind="prose">
+  <Select
+    icon="open-book"
+    label="Select prose font"
+    options={[
+      { label: 'STIX', selected: true, value: 'stix' },
+      { label: 'Atkinson', selected: false, value: 'atkinson' },
+    ]}
+    width="7em"
+  />
+</var-font-select>
+<var-font-select data-font-kind="code">
+  <Select
+    icon="code-branch"
+    label="Select code font"
+    options={[
+      { label: 'JetBrains', selected: true, value: 'jetbrains' },
+      { label: 'Atkinson', selected: false, value: 'atkinson' },
+    ]}
+    width="7.5em"
+  />
+</var-font-select>
 <Default><slot /></Default>
 
 <script>
@@ -65,4 +93,63 @@ import Default from '@astrojs/starlight/components/ThemeSelect.astro'
     }
   }
   customElements.define('var-palette-select', VarPaletteSelect)
+
+  // Font selectors — prose (--sl-font) and code (--sl-font-mono). Each swaps
+  // its default family for Atkinson Hyperlegible via a data-* attribute on
+  // <html>; the actual font-family values live in custom.css.
+  type FontKind = 'prose' | 'code'
+
+  interface FontConfig {
+    storageKey: string
+    attr: 'fontProse' | 'fontCode'
+    alt: string
+    fallback: string
+  }
+
+  const FONTS: Record<FontKind, FontConfig> = {
+    prose: { storageKey: 'var-font-prose', attr: 'fontProse', alt: 'atkinson', fallback: 'stix' },
+    code: { storageKey: 'var-font-code', attr: 'fontCode', alt: 'atkinson', fallback: 'jetbrains' },
+  }
+
+  const parseFont = (kind: FontKind, value: unknown): string =>
+    value === FONTS[kind].alt ? FONTS[kind].alt : FONTS[kind].fallback
+
+  const loadFont = (kind: FontKind): string =>
+    parseFont(
+      kind,
+      typeof localStorage !== 'undefined' && localStorage.getItem(FONTS[kind].storageKey),
+    )
+
+  function storeFont(kind: FontKind, value: string): void {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(FONTS[kind].storageKey, value)
+    }
+  }
+
+  /** Update <html>, and keep both matching font selects (header + mobile menu) in sync. */
+  function applyFont(kind: FontKind, value: string): void {
+    document.documentElement.dataset[FONTS[kind].attr] = value
+    document
+      .querySelectorAll<HTMLSelectElement>(`var-font-select[data-font-kind="${kind}"] select`)
+      .forEach((select) => {
+        select.value = value
+      })
+  }
+
+  class VarFontSelect extends HTMLElement {
+    constructor() {
+      super()
+      const kind = this.dataset.fontKind
+      if (kind !== 'prose' && kind !== 'code') return
+      applyFont(kind, loadFont(kind))
+      this.querySelector('select')?.addEventListener('change', (e) => {
+        if (e.currentTarget instanceof HTMLSelectElement) {
+          const value = parseFont(kind, e.currentTarget.value)
+          applyFont(kind, value)
+          storeFont(kind, value)
+        }
+      })
+    }
+  }
+  customElements.define('var-font-select', VarFontSelect)
 </script>

--- a/typescript/packages/website/src/styles/custom.css
+++ b/typescript/packages/website/src/styles/custom.css
@@ -236,6 +236,6 @@ h6 {
   --sl-font: 'Atkinson Hyperlegible', system-ui, sans-serif;
 }
 :root[data-font-code='atkinson'] {
-  --sl-font-mono: 'Atkinson Hyperlegible Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
-    monospace;
+  --sl-font-mono:
+    'Atkinson Hyperlegible Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }

--- a/typescript/packages/website/src/styles/custom.css
+++ b/typescript/packages/website/src/styles/custom.css
@@ -15,6 +15,20 @@
 @import '@fontsource/jetbrains-mono/600.css';
 @import '@fontsource/jetbrains-mono/700.css';
 
+/* Atkinson Hyperlegible — the alternative prose/code fonts offered by the
+   header font selectors (data-font-prose / data-font-code on <html>). A
+   font-face is only fetched when it's actually the selected family, so
+   default (STIX + JetBrains) visitors download none of these. The classic
+   Atkinson Hyperlegible sans ships 400/700 only; Atkinson Hyperlegible Mono
+   carries 600 for the editor's semibold UI. */
+@import '@fontsource/atkinson-hyperlegible/400.css';
+@import '@fontsource/atkinson-hyperlegible/400-italic.css';
+@import '@fontsource/atkinson-hyperlegible/700.css';
+@import '@fontsource/atkinson-hyperlegible-mono/400.css';
+@import '@fontsource/atkinson-hyperlegible-mono/400-italic.css';
+@import '@fontsource/atkinson-hyperlegible-mono/600.css';
+@import '@fontsource/atkinson-hyperlegible-mono/700.css';
+
 /*
  * "Norse" by Joël Carrouché (https://www.fontspace.com/norse-font-f21080),
  * freeware, free for personal and commercial use, embedding in web pages
@@ -145,8 +159,8 @@ h6 {
 }
 
 :root[data-theme='light'] {
-  --sl-font: 'STIX Two Text', Georgia, serif;
-  --sl-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  /* Fonts are theme-independent — set once in :root and switched by the header
+     selectors below (data-font-prose / data-font-code), never per light/dark. */
 
   /* Same story as :root — the header/nav uses gray-7 in light mode; give the
      page the identical light cream. */
@@ -206,4 +220,22 @@ h6 {
   --syn-number: #8a5a2b;
   --syn-heading: #3b2e20;
   --syn-meta: #8a7b66;
+}
+
+/*
+ * Header font selectors. The prose font (--sl-font) and code font
+ * (--sl-font-mono) default to STIX Two Text / JetBrains Mono in :root above;
+ * the header selects (src/components/ThemeSelect.astro) set data-font-prose /
+ * data-font-code on <html> to switch either one to Atkinson Hyperlegible. These
+ * selectors are [0,2,0] — matching :root[data-theme='light'] — so fonts stay
+ * out of the light/dark blocks to avoid a specificity tie. Headings keep Norse
+ * regardless (see the h1–h6 rule above). An inline head script in
+ * astro.config.mjs re-applies the stored choice before first paint.
+ */
+:root[data-font-prose='atkinson'] {
+  --sl-font: 'Atkinson Hyperlegible', system-ui, sans-serif;
+}
+:root[data-font-code='atkinson'] {
+  --sl-font-mono: 'Atkinson Hyperlegible Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
+    monospace;
 }

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -261,6 +261,12 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.4
         version: 6.43.4
+      '@fontsource/atkinson-hyperlegible':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/atkinson-hyperlegible-mono':
+        specifier: ^5.2.10
+        version: 5.2.10
       '@fontsource/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
@@ -891,6 +897,12 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.44.0':
     resolution: {integrity: sha512-0/m3A5b+lz2upyNq+wzZ1S69HRoJmyFs5LsR42lVZ9pmGRlBiSBYQpvqlji4DBj1+Riamxc0AvcCr5kuzOQeWA==}
+
+  '@fontsource/atkinson-hyperlegible-mono@5.2.10':
+    resolution: {integrity: sha512-BHT+CUi8GmNXuHkqRm+fZgN2K06GpxHBPO2T4xG2OI5yXcvv7L4gBCCtt84xUyawbccHvnkhp6AWBv4DzH+x+Q==}
+
+  '@fontsource/atkinson-hyperlegible@5.2.8':
+    resolution: {integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==}
 
   '@fontsource/jetbrains-mono@5.2.8':
     resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
@@ -4378,6 +4390,10 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.44.0':
     dependencies:
       '@expressive-code/core': 0.44.0
+
+  '@fontsource/atkinson-hyperlegible-mono@5.2.10': {}
+
+  '@fontsource/atkinson-hyperlegible@5.2.8': {}
 
   '@fontsource/jetbrains-mono@5.2.8': {}
 


### PR DESCRIPTION
…perlegible

Add two selects to the site header: prose font (STIX Two Text default or Atkinson Hyperlegible) and code font (JetBrains Mono default or Atkinson Hyperlegible Mono). The choice sets data-font-prose / data-font-code on <html> — driving --sl-font / --sl-font-mono — persists in localStorage, and is re-applied before first paint alongside the palette. Headings keep Norse. Unselected font-faces are never fetched, so default visitors pay no extra download.


Claude-Session: https://claude.ai/code/session_01REnnkT6VzjWj4r3LsZZidu