### PR TITLE
chore(website): lead the landing hero with "Be honest"

### DIFF
--- a/typescript/packages/website/src/content/docs/index.mdx
+++ b/typescript/packages/website/src/content/docs/index.mdx
@@ -3,7 +3,8 @@ title: Vár
 description: Executable markdown documentation for humans and agents. Turn your docs into tests.
 template: splash # Remove or comment out this line to display the site sidebar on this page.
 hero:
-  tagline: Executable markdown documentation for humans and agents. Turn your docs into tests.
+  title: Be honest
+  tagline: Your oaths, enforced.
   image:
     file: ../../assets/var-logo.webp
   actions:
@@ -48,6 +49,12 @@ import romanNumeralsStepsPython from '../../../../../../examples/python-pytest/s
 import romanNumeralsLogicPython from '../../../../../../examples/python-pytest/src/roman_numerals_example/__init__.py?raw';
 import romanNumeralsStepsRuby from '../../../../../../examples/ruby-rspec/steps/roman_numerals.steps.rb?raw';
 import romanNumeralsLogicRuby from '../../../../../../examples/ruby-rspec/lib/roman_numerals.rb?raw';
+
+You have requirements. Somewhere, tests get written. But are they testing what you
+actually need? Whether you're having conversations, writing specs, or using PRDs,
+something gets lost in translation. Vár closes that gap. It ties your requirements
+directly to the tests, making sure everyone keeps their word. Your oath becomes
+enforceable. Break it, and we catch it. Every time.
 
 ## Examples
 


### PR DESCRIPTION
Reframe the splash hero around Vár's oath conceit: headline "Be honest",
tagline "Your oaths, enforced.", and an intro paragraph pitching the
requirements-to-tests gap. Page title stays "Vár" for SEO.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YXRndoRdNHGDnR1X25zWDp