### PR TITLE
test(ts/cli): anchor the stderr warning filter on Node's own prefix

### DIFF
--- a/typescript/packages/cli/tests/run.test.ts
+++ b/typescript/packages/cli/tests/run.test.ts
@@ -15,10 +15,20 @@ function run(args: ReadonlyArray<string>, cwd: string) {
   return spawnSync(process.execPath, [BIN_TS, ...args], { cwd, encoding: 'utf8' })
 }
 
+// Node's notice is two lines, each with a fixed prefix:
+//
+//   (node:12345) ExperimentalWarning: globSync is an experimental feature ...
+//   (Use `node --trace-warnings ...` to show where the warning was created)
+//
+// Anchor on those prefixes rather than matching the text anywhere in the line,
+// so a CLI-emitted line that happens to contain it is still asserted on.
+const NODE_WARNING = /^\(node:\d+\) ExperimentalWarning:/
+const NODE_WARNING_HINT = /^\(Use `node --trace-warnings/
+
 function filterWarnings(stderr: string): string {
   return stderr
     .split('\n')
-    .filter((line) => !line.includes('ExperimentalWarning') && !line.includes('--trace-warnings'))
+    .filter((line) => !NODE_WARNING.test(line) && !NODE_WARNING_HINT.test(line))
     .join('\n')
     .trim()
 }


### PR DESCRIPTION
Refs #12. Rebased onto current `main` and cut down to the one item that is still real.

`packages/cli/tests/run.test.ts` asserts `filterWarnings(r.stderr)` is `''`, filtering out Node's one-time `ExperimentalWarning: globSync` notice. The filter matched `ExperimentalWarning` and `--trace-warnings` as **unanchored substrings**, so any line the CLI itself emitted containing either literal — a step name, a diagnostic, a hint — was silently dropped from the assertion instead of failing it.

Now anchored on the prefixes of Node's own two-line notice:

```
(node:12345) ExperimentalWarning: globSync is an experimental feature ...
(Use `node --trace-warnings ...` to show where the warning was created)
```

- `/^\(node:\d+\) ExperimentalWarning:/`
- `/^\(Use \`node --trace-warnings/`

## Verification

The suite being green does **not** verify the patterns here: on Node v22.22.2 the CLI emits nothing on stderr at all (`globSync` is no longer experimental), so the filter is inert and both the old and new versions pass trivially. I checked the patterns against the notice format directly instead — both notice lines are filtered, and CLI-style lines containing the same literals are kept:

```
filtered (want both true) : [ true, true ]
kept     (want both false): [ false, false ]
```

Worth noting on the back of that: the filter may be dead weight on current Node. Happy to delete it instead if you'd rather — but that's your call on the supported Node range, so this PR just makes it correct.

`pnpm check` and `pnpm build` green; `release/lint-commits.sh` OK.

## Dropped from the original PR

The second item — documenting that external consumers need `@varar/core` resolvable from the package holding their oaths — **no longer applies**, so I removed it rather than rebasing it:

- The generated virtual module now imports only `@varar/vitest/runtime`, and `plugin.ts:123-128` says explicitly that this is so importing `@varar/core` "would fail under pnpm's strict node_modules layout". That path is already fixed in the plugin.
- `resolve.dedupe` still lists `@varar/core`, but the module-level mutable state (`stepEntries`, `customTypes`) lives in `packages/varar/src/internal.ts`, and `@varar/varar` is a direct consumer dependency, so it dedupes fine. `@varar/core` has no module-level mutable state, so a split instance is harmless.

Documenting a requirement that isn't one seemed worse than dropping it.

The third item from #12 (the `registry.ts` non-null assertion) was already resolved. Left #12 open rather than auto-closing it, since only part of it is mine to close.