### PR TITLE
feat(py/var-config): expose a pure parse_var_config(text, source)

### DIFF
--- a/python/packages/var-config/src/var_config/__init__.py
+++ b/python/packages/var-config/src/var_config/__init__.py
@@ -1,3 +1,3 @@
-from var_config.config import VarConfig, read_var_config
+from var_config.config import VarConfig, parse_var_config, read_var_config
 
-__all__ = ["VarConfig", "read_var_config"]
+__all__ = ["VarConfig", "parse_var_config", "read_var_config"]

--- a/python/packages/var-config/src/var_config/config.py
+++ b/python/packages/var-config/src/var_config/config.py
@@ -18,53 +18,67 @@ class VarConfig:
     scanner_plugins: tuple[str, ...] = ()
 
 
-def _string_tuple(value: object, key: str, path: Path) -> tuple[str, ...]:
+def _string_tuple(value: object, key: str, source: str) -> tuple[str, ...]:
     if value is None:
         return ()
     if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
-        raise ValueError(f"{path}: '{key}' must be an array of strings")
+        raise ValueError(f"{source}: '{key}' must be an array of strings")
     return tuple(value)
 
 
-def read_var_config(root: str | Path) -> VarConfig:
-    """Read ``<root>/var.config.json``.
+def parse_var_config(text: str, source: str) -> VarConfig:
+    """Parse ``var.config.json`` ``text`` — a pure function, no file I/O.
 
-    Missing file -> empty config (tools no-op; matches every other port).
+    ``source`` labels every error message (typically the originating file
+    path). Mirrors TypeScript's ``parseVarConfig(jsonText, sourcePath)`` and
+    Java's ``VarConfig.parse(String, String)``: the file-reading edge lives in
+    :func:`read_var_config`, this is the functional core.
+
     Malformed JSON, wrong types, or unknown keys -> ``ValueError`` starting
-    with the file path — a typo'd config must fail loudly, never silently
-    discover nothing. See conformance/config/README.md for the shared rules.
+    with ``source`` — a typo'd config must fail loudly, never silently discover
+    nothing. See conformance/config/README.md for the shared rules.
     """
-    path = Path(root) / "var.config.json"
-    if not path.is_file():
-        return VarConfig()
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(text)
     except json.JSONDecodeError as e:
-        raise ValueError(f"{path}: invalid JSON: {e}") from e
+        raise ValueError(f"{source}: invalid JSON: {e}") from e
     if not isinstance(data, dict):
-        raise ValueError(f"{path}: top level must be an object")
+        raise ValueError(f"{source}: top level must be an object")
     unknown = set(data) - _KNOWN_KEYS
     if unknown:
-        raise ValueError(f"{path}: unknown key(s): {', '.join(sorted(unknown))}")
+        raise ValueError(f"{source}: unknown key(s): {', '.join(sorted(unknown))}")
     docs = data.get("docs")
     if docs is None:
         docs = {}
     if not isinstance(docs, dict):
-        raise ValueError(f"{path}: 'docs' must be an object")
+        raise ValueError(f"{source}: 'docs' must be an object")
     unknown_docs = set(docs) - _KNOWN_DOCS_KEYS
     if unknown_docs:
-        raise ValueError(f"{path}: unknown docs key(s): {', '.join(sorted(unknown_docs))}")
+        raise ValueError(f"{source}: unknown docs key(s): {', '.join(sorted(unknown_docs))}")
     snippets = data.get("snippets")
     if snippets is None:
         snippets = {}
     if not isinstance(snippets, dict) or not all(
         isinstance(k, str) and isinstance(v, str) for k, v in snippets.items()
     ):
-        raise ValueError(f"{path}: 'snippets' must be an object of strings")
+        raise ValueError(f"{source}: 'snippets' must be an object of strings")
     return VarConfig(
-        docs_include=_string_tuple(docs.get("include"), "docs.include", path),
-        docs_exclude=_string_tuple(docs.get("exclude"), "docs.exclude", path),
-        steps=_string_tuple(data.get("steps"), "steps", path),
+        docs_include=_string_tuple(docs.get("include"), "docs.include", source),
+        docs_exclude=_string_tuple(docs.get("exclude"), "docs.exclude", source),
+        steps=_string_tuple(data.get("steps"), "steps", source),
         snippets=dict(snippets),
-        scanner_plugins=_string_tuple(data.get("scannerPlugins"), "scannerPlugins", path),
+        scanner_plugins=_string_tuple(data.get("scannerPlugins"), "scannerPlugins", source),
     )
+
+
+def read_var_config(root: str | Path) -> VarConfig:
+    """Read ``<root>/var.config.json`` and parse it via :func:`parse_var_config`.
+
+    Missing file -> empty config (tools no-op; matches every other port). All
+    parsing/validation is delegated to the pure :func:`parse_var_config`; this
+    function is the imperative shell that only touches the filesystem.
+    """
+    path = Path(root) / "var.config.json"
+    if not path.is_file():
+        return VarConfig()
+    return parse_var_config(path.read_text(encoding="utf-8"), str(path))

--- a/python/packages/var-config/tests/test_config.py
+++ b/python/packages/var-config/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from var_config import VarConfig, read_var_config
+from var_config import VarConfig, parse_var_config, read_var_config
 
 
 def _write(tmp_path, body: str):
@@ -60,3 +60,17 @@ def test_falsy_wrong_type_snippets_raises(tmp_path):
     root = _write(tmp_path, '{"snippets": []}')
     with pytest.raises(ValueError, match="snippets"):
         read_var_config(root)
+
+
+def test_parse_var_config_is_pure_no_file_needed():
+    cfg = parse_var_config(
+        '{"docs": {"include": ["a/**/*.md"]}, "steps": ["**/*_steps.py"]}',
+        "<inline>",
+    )
+    assert cfg.docs_include == ("a/**/*.md",)
+    assert cfg.steps == ("**/*_steps.py",)
+
+
+def test_parse_var_config_labels_errors_with_source():
+    with pytest.raises(ValueError, match=r"<inline>: invalid JSON"):
+        parse_var_config("{ nope", "<inline>")


### PR DESCRIPTION
Closes #11.

TypeScript exposes `parseVarConfig(jsonText, sourcePath)` and Java `VarConfig.parse(String, String)` — pure text parsers separated from the file-reading edge. Python's `read_var_config(root)` fused read + parse, so there was no way to parse config text without a file on disk.

## Change

- Add **`parse_var_config(text: str, source: str) -> VarConfig`** — a pure function (no file I/O) that validates config text and labels every `ValueError` with the given `source`. This is the functional core, mirroring the other ports.
- Reimplement **`read_var_config(root)`** on top of it: it now only touches the filesystem (missing file → empty config; else read text and delegate), passing `str(path)` as the source so error messages are byte-for-byte unchanged.
- Export `parse_var_config` from the package.

## Tests

- Added a direct test that `parse_var_config` parses inline text with no file present, and that it labels errors with the caller-supplied `source`.
- Existing file-based tests and the shared config conformance suite stay green (18 + 8 passing); ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)