### PR TITLE
Remove the dynamic value type from the Rust author API

### DIFF
--- a/conformance/bundles/01-roman-numerals/numerals.steps.rs
+++ b/conformance/bundles/01-roman-numerals/numerals.steps.rs
@@ -1,9 +1,13 @@
 //! Rust sibling of `numerals.steps.ts` (bundle `01-roman-numerals`).
 //!
-//! Full-replacement state (ADR 0006): the `{result}` map is the whole state.
+//! Full-replacement state (ADR 0006), in the file's own context type.
 
-use std::collections::BTreeMap;
-use varar::{HandlerError, Steps, Value};
+use varar::{HandlerError, Steps};
+
+#[derive(Clone, Default)]
+pub struct Ctx {
+    pub result: String,
+}
 
 fn roman(n: i64) -> Option<&'static str> {
     match n {
@@ -15,40 +19,23 @@ fn roman(n: i64) -> Option<&'static str> {
     }
 }
 
-pub fn register(s: &mut Steps) {
-    s.stimulus("I convert {int} to roman numerals", |_state, n| {
-        let n = if let Value::Int(i) = n { i } else { 0 };
-        let mut m = BTreeMap::new();
-        if let Some(s) = roman(n) {
-            m.insert("result".to_string(), Value::from(s));
-        }
-        Ok(Some(Value::Map(m)))
+pub fn register(s: &mut Steps<Ctx>) {
+    s.stimulus("I convert {int} to roman numerals", |_ctx: Ctx, n: i64| {
+        Ok(Ctx {
+            result: roman(n).unwrap_or_default().to_string(),
+        })
     });
-    s.sensor("The result is {word}", |state, expected| {
-        // {word} greedily captures trailing punctuation ("I." not "I"); strip
-        // it, then throw on mismatch rather than returning (which would make
-        // the core compare the RAW captured "I." and wrongly fail). Returning
-        // None opts out, matching the .ts/.java sensors.
-        let expected = if let Value::String(s) = expected {
-            s
-        } else {
-            String::new()
-        };
+    // {word} greedily captures trailing punctuation ("I." not "I"), so this
+    // sensor asserts for itself rather than returning the slot for comparison.
+    s.sensor("The result is {word}", |ctx: Ctx, expected: String| -> Result<(), HandlerError> {
         let cleaned = expected.trim_end_matches(['.', '!', '?']);
-        let result = match &state {
-            Value::Map(m) => match m.get("result") {
-                Some(Value::String(s)) => s.clone(),
-                _ => String::new(),
-            },
-            _ => String::new(),
-        };
-        if cleaned != result {
-            return Err(HandlerError::new(format!("expected {cleaned} but got {result}")));
+        if cleaned != ctx.result {
+            return Err(HandlerError::new(format!("expected {cleaned} but got {}", ctx.result)));
         }
-        Ok(None)
+        Ok(())
     });
 }
 
-pub fn state() -> Value {
-    Value::Map(BTreeMap::new())
+pub fn state() -> Ctx {
+    Ctx::default()
 }

--- a/conformance/bundles/02-context-isolation/counter.steps.rs
+++ b/conformance/bundles/02-context-isolation/counter.steps.rs
@@ -1,33 +1,22 @@
 //! Rust sibling of `counter.steps.ts` (bundle `02-context-isolation`).
 
-use std::collections::BTreeMap;
-use varar::{HandlerError, Steps, Value};
+use varar::Steps;
 
-fn count_of(state: &Value) -> i64 {
-    match state {
-        Value::Map(m) => match m.get("count") {
-            Some(Value::Int(i)) => *i,
-            _ => 0,
-        },
-        _ => 0,
-    }
+#[derive(Clone, Default)]
+pub struct Ctx {
+    pub count: i64,
 }
 
-pub fn register(s: &mut Steps) {
-    s.stimulus("I increment", |state| {
-        let next = count_of(&state) + 1;
-        Ok(Some(Value::Map(BTreeMap::from([("count".to_string(), Value::Int(next))]))))
+pub fn register(s: &mut Steps<Ctx>) {
+    s.stimulus("I increment", |ctx: Ctx| {
+        Ok(Ctx {
+            count: ctx.count + 1,
+        })
     });
-    s.sensor("The count is {int}", |state, n| {
-        let count = count_of(&state);
-        let expected = if let Value::Int(i) = n { i } else { 0 };
-        if count != expected {
-            return Err(HandlerError::new(format!("expected {expected} but got {count}")));
-        }
-        Ok(None)
-    });
+    // One slot: return the observed count and let the core compare it.
+    s.sensor("The count is {int}", |ctx: Ctx, _expected: i64| Ok(ctx.count));
 }
 
-pub fn state() -> Value {
-    Value::Map(BTreeMap::from([("count".to_string(), Value::Int(0))]))
+pub fn state() -> Ctx {
+    Ctx::default()
 }

--- a/conformance/bundles/03-expected-failure/division.steps.rs
+++ b/conformance/bundles/03-expected-failure/division.steps.rs
@@ -1,17 +1,14 @@
 //! Rust sibling of `division.steps.ts` (bundle `03-expected-failure`).
 
-use varar::{HandlerError, Steps, Value};
+use varar::{HandlerError, Steps};
 
-pub fn register(s: &mut Steps) {
-    s.stimulus("I divide {int} by {int}", |state, _a, b| {
-        let b = if let Value::Int(i) = b { i } else { 0 };
+pub fn register(s: &mut Steps<()>) {
+    s.stimulus("I divide {int} by {int}", |ctx: (), _a: i64, b: i64| {
         if b == 0 {
             return Err(HandlerError::new("division by zero"));
         }
-        Ok(Some(state))
+        Ok(ctx)
     });
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/04-tables-and-docstrings/echo.steps.rs
+++ b/conformance/bundles/04-tables-and-docstrings/echo.steps.rs
@@ -1,13 +1,11 @@
 //! Rust sibling of `echo.steps.ts` (bundle `04-tables-and-docstrings`).
 
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    // The doc string is this sensor's only slot, so it is returned bare; the
-    // core compares it against the input (compareDocString); equal passes.
-    s.sensor("I echo the following:", |_state, doc| Ok(Some(doc)));
+pub fn register(s: &mut Steps<()>) {
+    // The doc string is this sensor's only slot: echo it back and the core
+    // compares it against the input.
+    s.sensor("I echo the following:", |_ctx: (), doc: String| Ok(doc));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/05-ambiguous-match/cukes.steps.rs
+++ b/conformance/bundles/05-ambiguous-match/cukes.steps.rs
@@ -1,13 +1,11 @@
 //! Rust sibling of `cukes.steps.ts` (bundle `05-ambiguous-match`).
 
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
+pub fn register(s: &mut Steps<()>) {
     // Both expressions match "I have 5 cukes" → ambiguous-match diagnostic.
-    s.stimulus("I have {int} cukes", |_state, _n| Ok(None));
-    s.stimulus("I have 5 cukes", |_state| Ok(None));
+    s.stimulus("I have {int} cukes", |ctx: (), _n: i64| Ok(ctx));
+    s.stimulus("I have 5 cukes", |ctx: ()| Ok(ctx));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/06-doc-string-mismatch/echo.steps.rs
+++ b/conformance/bundles/06-doc-string-mismatch/echo.steps.rs
@@ -1,13 +1,11 @@
 //! Rust sibling of `echo.steps.ts` (bundle `06-doc-string-mismatch`).
 
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    // Returns the WRONG string (bare — the doc string is the only slot); the
-    // core compares it to the doc string and throws DocStringMismatchError.
-    s.sensor("I echo the following:", |_state, _doc| Ok(Some(Value::from("goodbye"))));
+pub fn register(s: &mut Steps<()>) {
+    // Returns the WRONG string for the doc-string slot; the core compares it
+    // and fails with DocStringMismatch.
+    s.sensor("I echo the following:", |_ctx: (), _doc: String| Ok("goodbye".to_string()));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/07-row-check-mismatch/report.steps.rs
+++ b/conformance/bundles/07-row-check-mismatch/report.steps.rs
@@ -1,19 +1,17 @@
 //! Rust sibling of `report.steps.ts` (bundle `07-row-check-mismatch`).
 
 use std::collections::BTreeMap;
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    // Header-bound row step: returns its computed columns; the core diffs them
-    // against the row cells (rowChecks). score 99 ≠ 10 → CellMismatchError.
-    s.sensor("I report the score and grade", |_state, _row| {
-        Ok(Some(Value::Map(BTreeMap::from([
-            ("score".to_string(), Value::from("99")),
-            ("grade".to_string(), Value::from("A")),
-        ]))))
+pub fn register(s: &mut Steps<()>) {
+    // Header-bound row: the row arrives keyed by column and the computed
+    // columns go back the same way. score 99 ≠ 10 → CellMismatch.
+    s.sensor("I report the score and grade", |_ctx: (), _row: BTreeMap<String, String>| {
+        Ok(BTreeMap::from([
+            ("score".to_string(), "99".to_string()),
+            ("grade".to_string(), "A".to_string()),
+        ]))
     });
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/08-string-capture/greet.steps.rs
+++ b/conformance/bundles/08-string-capture/greet.steps.rs
@@ -1,11 +1,9 @@
 //! Rust sibling of `greet.steps.ts` (bundle `08-string-capture`).
 
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.stimulus("I greet {string}", |_state, _name| Ok(None));
+pub fn register(s: &mut Steps<()>) {
+    s.stimulus("I greet {string}", |ctx: (), _name: String| Ok(ctx));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/09-expected-message-mismatch/boom.steps.rs
+++ b/conformance/bundles/09-expected-message-mismatch/boom.steps.rs
@@ -1,13 +1,13 @@
 //! Rust sibling of `boom.steps.ts` (bundle `09-expected-message-mismatch`).
 
-use varar::{HandlerError, Steps, Value};
+use varar::{HandlerError, Steps};
 
-pub fn register(s: &mut Steps) {
-    // Throws a message that does NOT contain the expected substring "expected
-    // message", so the expected-failure is NOT satisfied → the example fails.
-    s.stimulus("I always boom", |_state| Err(HandlerError::new("actual different error")));
+pub fn register(s: &mut Steps<()>) {
+    // Fails with a message that does NOT contain the expected substring, so
+    // the expected-failure is not satisfied → the example fails.
+    s.stimulus("I always boom", |_ctx: ()| {
+        Err::<(), _>(HandlerError::new("actual different error"))
+    });
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/10-error-fence-without-step/cukes.steps.rs
+++ b/conformance/bundles/10-error-fence-without-step/cukes.steps.rs
@@ -1,14 +1,11 @@
 //! Rust sibling of `cukes.steps.ts` (bundle `10-error-fence-without-step`).
 
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    // The prose matches no step, so the `error` fence has nothing to run →
-    // error-fence-without-step diagnostic, and the example is dropped. This
-    // step exists only so the registry matches the other ports'.
-    s.stimulus("I have {int} cukes", |_state, _n| Ok(None));
+pub fn register(s: &mut Steps<()>) {
+    // The prose matches no step, so the `error` fence has nothing to run.
+    // This step exists only so the registry matches the other ports'.
+    s.stimulus("I have {int} cukes", |ctx: (), _n: i64| Ok(ctx));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/11-emoji-offsets/greet.steps.rs
+++ b/conformance/bundles/11-emoji-offsets/greet.steps.rs
@@ -1,13 +1,14 @@
 //! Rust sibling of `greet.steps.ts` (bundle `11-emoji-offsets`).
 
-use varar::{Steps, Value};
+use varar::{HandlerError, Steps};
 
-pub fn register(s: &mut Steps) {
-    // The list item is followed by a table, appended as a trailing arg, so this
-    // sensor's slots are {string} + the table (returns nothing → passes).
-    s.sensor("I greet {string}", |_state, _name, _table| Ok(None));
+pub fn register(s: &mut Steps<()>) {
+    // The list item is followed by a table, appended as a trailing slot, so
+    // this sensor's slots are {string} + the table; it asserts nothing.
+    s.sensor(
+        "I greet {string}",
+        |_ctx: (), _name: String, _table: Vec<Vec<String>>| -> Result<(), HandlerError> { Ok(()) },
+    );
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/12-combining-marks/greet.steps.rs
+++ b/conformance/bundles/12-combining-marks/greet.steps.rs
@@ -1,11 +1,9 @@
 //! Rust sibling of `greet.steps.ts` (bundle `12-combining-marks`).
 
-use varar::{Steps, Value};
+use varar::{HandlerError, Steps};
 
-pub fn register(s: &mut Steps) {
-    s.sensor("I greet {string}", |_state, _name| Ok(None));
+pub fn register(s: &mut Steps<()>) {
+    s.sensor("I greet {string}", |_ctx: (), _name: String| -> Result<(), HandlerError> { Ok(()) });
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/13-custom-parameter-type/airports.steps.rs
+++ b/conformance/bundles/13-custom-parameter-type/airports.steps.rs
@@ -1,39 +1,31 @@
 //! Rust sibling of `airports.steps.ts` (bundle `13-custom-parameter-type`).
 
-use std::collections::BTreeMap;
-use std::rc::Rc;
-use varar::{HandlerError, ParseFn, Steps, Value};
+use varar::{HandlerError, Steps};
 
-pub fn register(s: &mut Steps) {
-    // Custom {airport} parameter type: IATA code, lowercased by parse. The
-    // sensor asserts the lowercasing, so an identity parse would fail.
-    let parse: ParseFn = Rc::new(|g: &[&str]| Value::from(g[0].to_lowercase()));
-    s.param("airport", "[A-Z]{3}", parse, None);
-
-    s.stimulus("I fly to {airport}", |_state, dest| {
-        Ok(Some(Value::Map(BTreeMap::from([("dest".to_string(), dest)]))))
-    });
-    s.sensor("The destination code is {word}", |state, expected| {
-        let expected = if let Value::String(s) = expected {
-            s
-        } else {
-            String::new()
-        };
-        let cleaned = expected.trim_end_matches(['.', '!', '?']);
-        let dest = match &state {
-            Value::Map(m) => match m.get("dest") {
-                Some(Value::String(s)) => s.clone(),
-                _ => String::new(),
-            },
-            _ => String::new(),
-        };
-        if cleaned != dest {
-            return Err(HandlerError::new(format!("expected {cleaned} but got {dest}")));
-        }
-        Ok(None)
-    });
+#[derive(Clone, Default)]
+pub struct Ctx {
+    pub dest: String,
 }
 
-pub fn state() -> Value {
-    Value::Null
+pub fn register(s: &mut Steps<Ctx>) {
+    // Custom {airport} parameter type, declared in terms of the Rust type it
+    // produces: an IATA code lowercased by parse. The sensor asserts the
+    // lowercasing, so an identity parse would fail.
+    s.param("airport", "[A-Z]{3}", |g: &[&str]| g[0].to_lowercase(), None);
+
+    s.stimulus("I fly to {airport}", |_ctx: Ctx, dest: String| Ok(Ctx { dest }));
+    s.sensor(
+        "The destination code is {word}",
+        |ctx: Ctx, expected: String| -> Result<(), HandlerError> {
+            let cleaned = expected.trim_end_matches(['.', '!', '?']);
+            if cleaned != ctx.dest {
+                return Err(HandlerError::new(format!("expected {cleaned} but got {}", ctx.dest)));
+            }
+            Ok(())
+        },
+    );
+}
+
+pub fn state() -> Ctx {
+    Ctx::default()
 }

--- a/conformance/bundles/14-stateless-steps/squares.steps.rs
+++ b/conformance/bundles/14-stateless-steps/squares.steps.rs
@@ -1,20 +1,14 @@
 //! Rust sibling of `squares.steps.ts` (bundle `14-stateless-steps`).
 //!
-//! Pure steps — nothing to arrange or evolve — so `state()` is the bare
-//! [`Value::Null`] every handler ignores.
+//! Pure steps — nothing to arrange or evolve — so the context is the unit type.
 
-use varar::{Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.stimulus("I warm up my mental math", |_state| Ok(None));
-    // Two slots ({int}, {int}); the handler uses only the first and returns
-    // both computed columns [n, n*n] for positional comparison.
-    s.sensor("The square of {int} is {int}.", |_state, n, _square| {
-        let n = if let Value::Int(i) = n { i } else { 0 };
-        Ok(Some(Value::List(vec![Value::Int(n), Value::Int(n * n)])))
-    });
+pub fn register(s: &mut Steps<()>) {
+    s.stimulus("I warm up my mental math", |ctx: ()| Ok(ctx));
+    // Two slots ({int}, {int}): two ints in, two ints out, compared
+    // positionally — the same contract as the .ts sibling's `[n, n * n]`.
+    s.sensor("The square of {int} is {int}.", |_ctx: (), n: i64, _square: i64| Ok((n, n * n)));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/conformance/bundles/15-custom-parameter-format/money.steps.rs
+++ b/conformance/bundles/15-custom-parameter-format/money.steps.rs
@@ -1,32 +1,26 @@
 //! Rust sibling of `money.steps.ts` (bundle `15-custom-parameter-format`).
 //!
-//! Money is encoded as a bare [`Value::Float`] (pounds); `format` renders it
-//! back in document notation, so the pinned mismatch reads `£2.60` / `£2.55`.
+//! Money is a bare `f64` (pounds); `format` renders it back in the document's
+//! notation, so the pinned mismatch reads `£2.60` / `£2.55`.
 
-use std::rc::Rc;
-use varar::{FormatFn, ParseFn, Steps, Value};
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    let parse: ParseFn = Rc::new(|g: &[&str]| {
-        let raw = g[0];
-        let value = raw
-            .strip_prefix('£')
-            .unwrap_or(raw)
-            .parse::<f64>()
-            .unwrap_or(0.0);
-        Value::Float(value)
-    });
-    let format: FormatFn = Rc::new(|v: &Value| match v {
-        Value::Float(x) => Some(format!("£{x:.2}")),
-        _ => None,
-    });
-    s.param("money", r"£\d+\.\d{2}", parse, Some(format));
+pub fn register(s: &mut Steps<()>) {
+    s.param(
+        "money",
+        r"£\d+\.\d{2}",
+        |g: &[&str]| {
+            g[0].strip_prefix('£')
+                .unwrap_or(g[0])
+                .parse::<f64>()
+                .unwrap_or(0.0)
+        },
+        Some(Box::new(|v: &f64| format!("£{v:.2}"))),
+    );
 
     // Returns the WRONG money on purpose; the golden pins the formatted actual
     // "£2.60", proving mismatches render through `format`.
-    s.sensor("The late fee is {money}", |_state, _expected| Ok(Some(Value::Float(2.6))));
+    s.sensor("The late fee is {money}", |_ctx: (), _expected: f64| Ok(2.6));
 }
 
-pub fn state() -> Value {
-    Value::Null
-}
+pub fn state() {}

--- a/doc/adr/0006-rust-port.md
+++ b/doc/adr/0006-rust-port.md
@@ -68,3 +68,34 @@ already implements, matching the JVM ports rather than the dynamic ones:
   equivalent. Recorded here so it is not mistaken for a bug.
 - The cargo test-framework integration mechanism is its own decision:
   [ADR 0007](0007-rust-cargo-test-integration.md).
+
+
+## Amendment (2026-07-20) — a minimal author surface
+
+Following the same pass on the Go port, the Rust authoring API no longer
+exposes the core's dynamic `Value` as the way steps are written:
+
+- **`Steps<C>` is generic in the context type.** A step file declares its own
+  `Ctx` and handlers take and return it; a stimulus returns the whole next
+  `Ctx`. `varar-core` therefore treats the state as an opaque `Rc<dyn Any>` —
+  it threads it between a file's steps and replaces it wholesale, but never
+  compares, serializes, or inspects it, so no conformance artifact changes.
+- **Slots arrive as the handler's own Rust types**, via `FromSlot`/`ToSlot`.
+  A sensor returns one value per slot — TypeScript spells the two-slot case as
+  the tuple `[n, n * n]`, Rust as `(n, n * n)` — and a sensor that asserts for
+  itself returns `()` instead (the opt-out a greedy `{word}` capture needs).
+- **`param` is declared in terms of the type it produces**, so a `{date}`
+  yields a `Date` directly rather than a map the handler has to unpack.
+
+Unlike Go's reflective equivalent, all of this is checked by the compiler:
+a wrong arity, an unreadable slot type, or a sensor whose results do not match
+its slots is a build error rather than a run-time one.
+
+`Value` remains exported, but only as the escape hatch — a slot with no natural
+Rust spelling, and the type named when implementing `FromSlot`/`ToSlot` for a
+domain type. Rust has no reflection, so unlike Go (where a plain struct maps
+automatically) a domain type states the mapping once. No step function in the
+corpus or the sample project mentions `Value`.
+
+The core's fixed-arity `Handler::sync*` conveniences are retained for the core's
+own tests and non-facade consumers; they are not the author API.

--- a/examples/rust-cargotest/src/library_example.rs
+++ b/examples/rust-cargotest/src/library_example.rs
@@ -83,3 +83,32 @@ pub fn late_fee(due: Date, returned_on: Date) -> i64 {
 pub fn may_borrow(dues: &[Date], on: Date) -> bool {
     dues.iter().all(|due| due.serial() >= on.serial())
 }
+
+// Slot conversions, so a `Date` can be a step parameter directly — Rust has no
+// reflection, so a domain type says once how it maps to and from a slot.
+impl varar::FromSlot for Date {
+    fn from_slot(value: &varar::Value) -> Result<Date, varar::HandlerError> {
+        let varar::Value::Map(m) = value else {
+            return Err(varar::HandlerError::new("expected a date"));
+        };
+        let field = |k: &str| match m.get(k) {
+            Some(varar::Value::Int(i)) => Ok(*i),
+            _ => Err(varar::HandlerError::new(format!("date is missing {k}"))),
+        };
+        Ok(Date {
+            year: field("year")?,
+            month: field("month")?,
+            day: field("day")?,
+        })
+    }
+}
+
+impl varar::ToSlot for Date {
+    fn to_slot(&self) -> varar::Value {
+        varar::Value::Map(std::collections::BTreeMap::from([
+            ("year".to_string(), varar::Value::Int(self.year)),
+            ("month".to_string(), varar::Value::Int(self.month)),
+            ("day".to_string(), varar::Value::Int(self.day)),
+        ]))
+    }
+}

--- a/examples/rust-cargotest/src/steps/deep_thought.rs
+++ b/examples/rust-cargotest/src/steps/deep_thought.rs
@@ -1,7 +1,6 @@
-use varar::{Steps, Value};
+use super::Ctx;
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.sensor("life, the universe and everything is {int}", |_state, _answer| {
-        Ok(Some(Value::Int(42)))
-    });
+pub fn register(s: &mut Steps<Ctx>) {
+    s.sensor("life, the universe and everything is {int}", |_ctx: Ctx, _answer: i64| Ok(42));
 }

--- a/examples/rust-cargotest/src/steps/hello_var.rs
+++ b/examples/rust-cargotest/src/steps/hello_var.rs
@@ -1,22 +1,22 @@
-use super::{as_int, as_str, smap};
-use varar::{Steps, Value};
+use super::Ctx;
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.stimulus("I greet {string}", |state, name| {
-        let mut m = smap(&state);
-        m.insert("greeting".to_string(), Value::from(format!("Hello, {}!", as_str(&name))));
-        Ok(Some(Value::Map(m)))
+pub fn register(s: &mut Steps<Ctx>) {
+    s.stimulus("I greet {string}", |ctx: Ctx, name: String| {
+        Ok(Ctx {
+            greeting: format!("Hello, {name}!"),
+            ..ctx
+        })
     });
 
-    s.sensor("the greeting should be {string}", |state, _expected| {
-        Ok(smap(&state).get("greeting").cloned())
+    s.sensor("the greeting should be {string}", |ctx: Ctx, _expected: String| Ok(ctx.greeting));
+
+    s.stimulus("expression `{int}+{int}`", |ctx: Ctx, a: i64, b: i64| {
+        Ok(Ctx {
+            result: a + b,
+            ..ctx
+        })
     });
 
-    s.stimulus("expression `{int}+{int}`", |state, a, b| {
-        let mut m = smap(&state);
-        m.insert("result".to_string(), Value::Int(as_int(&a) + as_int(&b)));
-        Ok(Some(Value::Map(m)))
-    });
-
-    s.sensor("evaluate to `{int}`", |state, _expected| Ok(smap(&state).get("result").cloned()));
+    s.sensor("evaluate to `{int}`", |ctx: Ctx, _expected: i64| Ok(ctx.result));
 }

--- a/examples/rust-cargotest/src/steps/library.rs
+++ b/examples/rust-cargotest/src/steps/library.rs
@@ -1,106 +1,70 @@
-use super::{as_int, smap, vmap};
+use super::{Ctx, Loan};
 use crate::library_example::{
     Date, FEE_PER_DAY, format_date, format_money, late_fee, may_borrow, parse_date, parse_money,
 };
-use std::rc::Rc;
-use varar::{FormatFn, ParseFn, Steps, Value};
+use varar::{HandlerError, Steps};
 
-fn date_value(d: Date) -> Value {
-    vmap(vec![
-        ("year", Value::Int(d.year)),
-        ("month", Value::Int(d.month)),
-        ("day", Value::Int(d.day)),
-    ])
-}
+pub fn register(s: &mut Steps<Ctx>) {
+    // Custom parameter types, declared in terms of the Rust types they produce:
+    // a Date, pennies as an i64, and a plain title String.
+    s.param(
+        "date",
+        r"[A-Z][a-z]+ \d{1,2}, \d{4}",
+        |g: &[&str]| parse_date(g[0]),
+        Some(Box::new(|d: &Date| format_date(*d))),
+    );
+    s.param(
+        "money",
+        r"£\d+(?:\.\d+)?|\d+p",
+        |g: &[&str]| parse_money(g[0]),
+        Some(Box::new(|pennies: &i64| format_money(*pennies))),
+    );
+    s.param(
+        "title",
+        r"\*[^*]+\*",
+        |g: &[&str]| {
+            g[0].strip_prefix('*')
+                .and_then(|t| t.strip_suffix('*'))
+                .unwrap_or(g[0])
+                .to_string()
+        },
+        Some(Box::new(|t: &String| format!("*{t}*"))),
+    );
 
-fn value_date(v: &Value) -> Date {
-    let m = smap(v);
-    Date {
-        year: as_int(&m["year"]),
-        month: as_int(&m["month"]),
-        day: as_int(&m["day"]),
-    }
-}
-
-fn loan_due(loan: &Value) -> Date {
-    value_date(&smap(loan)["due"])
-}
-
-fn loans_of(state: &Value) -> Vec<Value> {
-    match smap(state).get("loans") {
-        Some(Value::List(l)) => l.clone(),
-        _ => Vec::new(),
-    }
-}
-
-pub fn register(s: &mut Steps) {
-    let date_parse: ParseFn = Rc::new(|g: &[&str]| date_value(parse_date(g[0])));
-    let date_format: FormatFn = Rc::new(|v: &Value| Some(format_date(value_date(v))));
-    s.param("date", r"[A-Z][a-z]+ \d{1,2}, \d{4}", date_parse, Some(date_format));
-
-    let money_parse: ParseFn = Rc::new(|g: &[&str]| Value::Int(parse_money(g[0])));
-    let money_format: FormatFn = Rc::new(|v: &Value| match v {
-        Value::Int(pennies) => Some(format_money(*pennies)),
-        _ => None,
-    });
-    s.param("money", r"£\d+(?:\.\d+)?|\d+p", money_parse, Some(money_format));
-
-    let title_parse: ParseFn = Rc::new(|g: &[&str]| {
-        let raw = g[0];
-        let inner = raw
-            .strip_prefix('*')
-            .and_then(|s| s.strip_suffix('*'))
-            .unwrap_or(raw);
-        Value::from(inner.to_string())
-    });
-    let title_format: FormatFn = Rc::new(|v: &Value| match v {
-        Value::String(t) => Some(format!("*{t}*")),
-        _ => None,
-    });
-    s.param("title", r"\*[^*]+\*", title_parse, Some(title_format));
-
-    s.stimulus("borrowed {title}, due back on {date}", |state, title, due| {
-        let mut m = smap(&state);
-        let mut loans = loans_of(&state);
-        loans.push(vmap(vec![("title", title), ("due", due)]));
-        m.insert("loans".to_string(), Value::List(loans));
-        Ok(Some(Value::Map(m)))
+    s.stimulus("borrowed {title}, due back on {date}", |ctx: Ctx, title: String, due: Date| {
+        let mut loans = ctx.loans.clone();
+        loans.push(Loan { title, due });
+        Ok(Ctx { loans, ..ctx })
     });
 
-    s.stimulus("returns it on {date}", |state, returned_on| {
-        let returned = value_date(&returned_on);
-        let mut fee = 0;
-        for loan in loans_of(&state) {
-            fee += late_fee(loan_due(&loan), returned);
+    s.stimulus("returns it on {date}", |ctx: Ctx, returned: Date| {
+        let fee = ctx.loans.iter().map(|l| late_fee(l.due, returned)).sum();
+        Ok(Ctx { fee, ..ctx })
+    });
+
+    s.sensor("owes a {money} late fee", |ctx: Ctx, _expected: i64| Ok(ctx.fee));
+
+    s.sensor("{money} for each day overdue", |_ctx: Ctx, _expected: i64| Ok(FEE_PER_DAY));
+
+    s.stimulus("asks to borrow {title} on {date}", |ctx: Ctx, _title: String, on: Date| {
+        let dues: Vec<Date> = ctx.loans.iter().map(|l| l.due).collect();
+        Ok(Ctx {
+            granted: may_borrow(&dues, on),
+            ..ctx
+        })
+    });
+
+    s.sensor("the library refuses", |ctx: Ctx| {
+        if ctx.granted {
+            return Err(HandlerError::new("expected the library to refuse"));
         }
-        let mut m = smap(&state);
-        m.insert("fee".to_string(), Value::Int(fee));
-        Ok(Some(Value::Map(m)))
+        Ok(())
     });
 
-    s.sensor("owes a {money} late fee", |state, _expected| Ok(smap(&state).get("fee").cloned()));
-
-    s.sensor("{money} for each day overdue", |_state, _expected| Ok(Some(Value::Int(FEE_PER_DAY))));
-
-    s.stimulus("asks to borrow {title} on {date}", |state, _title, on| {
-        let on = value_date(&on);
-        let dues: Vec<Date> = loans_of(&state).iter().map(loan_due).collect();
-        let mut m = smap(&state);
-        m.insert("granted".to_string(), Value::Bool(may_borrow(&dues, on)));
-        Ok(Some(Value::Map(m)))
-    });
-
-    s.sensor("the library refuses", |state| {
-        if matches!(smap(&state).get("granted"), Some(Value::Bool(true))) {
-            panic!("expected the library to refuse");
+    s.sensor("the library agrees", |ctx: Ctx| {
+        if !ctx.granted {
+            return Err(HandlerError::new("expected the library to agree"));
         }
-        Ok(None)
-    });
-
-    s.sensor("the library agrees", |state| {
-        if !matches!(smap(&state).get("granted"), Some(Value::Bool(true))) {
-            panic!("expected the library to agree");
-        }
-        Ok(None)
+        Ok(())
     });
 }

--- a/examples/rust-cargotest/src/steps/mod.rs
+++ b/examples/rust-cargotest/src/steps/mod.rs
@@ -1,15 +1,16 @@
-//! Step definitions for every spec, plus the registry/context glue.
+//! Step definitions for every spec, plus the registry glue.
 //!
-//! Rust has no import-for-side-effect story, so — like the Java/Kotlin ports,
-//! and unlike TypeScript/Python's module-scope accumulator — each step file
-//! exposes a `register(&mut Steps)` that adds its steps to the injected builder,
-//! and [`build_registry`] threads one builder through them all. The state is a
-//! **full replacement** value (varar-core's model), not a shallow-merged
-//! partial: a `stimulus` returns the whole next state.
+//! Rust has no import-for-side-effect story, so — like the Java/Kotlin/Go/C#
+//! ports, and unlike TypeScript/Python's module-scope accumulator — each step
+//! file exposes a `register(&mut Steps<Ctx>)` that adds its steps to the
+//! injected builder, and [`build_registry`] threads one builder through them
+//! all. The state is a **full replacement** value: a stimulus returns the whole
+//! next `Ctx`.
+//!
+//! Note what is absent: `varar::Value`. The context is this crate's own `Ctx`,
+//! and every slot arrives as the Rust type the handler declares.
 
-use std::collections::BTreeMap;
-use varar::Steps;
-use varar_core::value::Value;
+use varar::{Registry, Steps};
 
 pub mod deep_thought;
 pub mod hello_var;
@@ -18,11 +19,31 @@ pub mod roman_numerals;
 pub mod tables_and_docstrings;
 pub mod yahtzee;
 
-use varar_core::registry::{Registry, create_registry};
+use crate::library_example::Date;
+
+/// This project's step state. `varar-core` keys it per step file, so each spec
+/// starts from `Ctx::default()`.
+#[derive(Clone, Default)]
+pub struct Ctx {
+    // hello-var
+    pub greeting: String,
+    pub result: i64,
+    // library
+    pub loans: Vec<Loan>,
+    pub fee: i64,
+    pub granted: bool,
+}
+
+/// One borrowed title and its due date.
+#[derive(Clone)]
+pub struct Loan {
+    pub title: String,
+    pub due: Date,
+}
 
 /// The combined registry for all specs.
 pub fn build_registry() -> Registry {
-    let mut s = Steps::from_registry(create_registry());
+    let mut s = Steps::<Ctx>::new();
     hello_var::register(&mut s);
     deep_thought::register(&mut s);
     tables_and_docstrings::register(&mut s);
@@ -32,51 +53,10 @@ pub fn build_registry() -> Registry {
     s.into_registry()
 }
 
-/// Fresh initial state per step file (varar-core keys context by a step's source
-/// file — the path captured at each `stimulus`/`sensor` call site). Matched by
-/// filename suffix so it's independent of the path prefix `#[track_caller]`
-/// reports. Files whose steps are pure return [`Value::Null`]. A plain `fn`
-/// (not a closure) so the adapter can move it across the libtest thread
-/// boundary.
-pub fn context_value(file: &str) -> Value {
-    if file.ends_with("hello_var.rs") {
-        vmap(vec![("greeting", Value::from("")), ("result", Value::Int(0))])
-    } else if file.ends_with("library.rs") {
-        vmap(vec![
-            ("loans", Value::List(vec![])),
-            ("fee", Value::Int(0)),
-            ("granted", Value::Bool(false)),
-        ])
-    } else {
-        Value::Null
-    }
-}
-
-// --- shared Value helpers ---------------------------------------------------
-
-/// Builds a [`Value::Map`] from `(key, value)` pairs.
-pub(crate) fn vmap(pairs: Vec<(&str, Value)>) -> Value {
-    Value::Map(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
-}
-
-/// Clones the underlying map of a [`Value::Map`] (empty for anything else).
-pub(crate) fn smap(v: &Value) -> BTreeMap<String, Value> {
-    match v {
-        Value::Map(m) => m.clone(),
-        _ => BTreeMap::new(),
-    }
-}
-
-pub(crate) fn as_int(v: &Value) -> i64 {
-    match v {
-        Value::Int(i) => *i,
-        _ => panic!("expected an integer, got {v:?}"),
-    }
-}
-
-pub(crate) fn as_str(v: &Value) -> String {
-    match v {
-        Value::String(s) => s.clone(),
-        _ => panic!("expected a string, got {v:?}"),
-    }
+/// Fresh initial state per step file. Every spec starts from `Ctx::default()`;
+/// `varar-core` keys state per step file, so specs never see each other's. A
+/// plain `fn` (not a closure) so the adapter can move it across the libtest
+/// thread boundary.
+pub fn context_value(_file: &str) -> std::rc::Rc<dyn std::any::Any> {
+    std::rc::Rc::new(Ctx::default())
 }

--- a/examples/rust-cargotest/src/steps/roman_numerals.rs
+++ b/examples/rust-cargotest/src/steps/roman_numerals.rs
@@ -1,15 +1,15 @@
-use super::{as_str, smap, vmap};
+use super::Ctx;
 use crate::roman_numerals_example::to_roman;
-use varar::{Steps, Value};
+use std::collections::BTreeMap;
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.sensor("a decimal and a roman number", |_state, row| {
-        let m = smap(&row);
-        let decimal = as_str(&m["decimal"]);
+pub fn register(s: &mut Steps<Ctx>) {
+    s.sensor("a decimal and a roman number", |_ctx: Ctx, row: BTreeMap<String, String>| {
+        let decimal = row["decimal"].clone();
         let roman = to_roman(decimal.parse().expect("decimal"));
-        Ok(Some(vmap(vec![
-            ("decimal", Value::from(decimal)),
-            ("roman", Value::from(roman)),
-        ])))
+        Ok(BTreeMap::from([
+            ("decimal".to_string(), decimal),
+            ("roman".to_string(), roman),
+        ]))
     });
 }

--- a/examples/rust-cargotest/src/steps/tables_and_docstrings.rs
+++ b/examples/rust-cargotest/src/steps/tables_and_docstrings.rs
@@ -1,35 +1,21 @@
-use super::{as_str, vmap};
-use varar::{Steps, Value};
+use super::Ctx;
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.sensor("Uppercase each one:", |_state, table| {
-        let rows = match &table {
-            Value::List(rows) => rows,
-            other => panic!("expected a table, got {other:?}"),
-        };
-        let out: Vec<Value> = rows
+pub fn register(s: &mut Steps<Ctx>) {
+    // A whole-table slot arrives as rows of cells, and the computed table goes
+    // back the same way — compared positionally against the input's columns.
+    s.sensor("Uppercase each one:", |_ctx: Ctx, table: Vec<Vec<String>>| {
+        Ok(table
             .iter()
             .skip(1)
-            .map(|row| {
-                let before = match row {
-                    Value::List(cells) => as_str(&cells[0]),
-                    other => panic!("expected a row, got {other:?}"),
-                };
-                let after = before.to_uppercase();
-                vmap(vec![
-                    ("before", Value::from(before)),
-                    ("after", Value::from(after)),
-                ])
-            })
-            .collect();
-        Ok(Some(Value::List(out)))
+            .map(|row| vec![row[0].clone(), row[0].to_uppercase()])
+            .collect::<Vec<Vec<String>>>())
     });
 
-    s.sensor("Greet {word}:", |_state, name, _doc| {
-        let name = as_str(&name);
-        Ok(Some(Value::List(vec![
-            Value::from(name.clone()),
-            Value::from(format!("Hello, {name}!\n")),
-        ])))
+    // Two slots — the {word} capture and the trailing doc string — so two
+    // strings in, two strings out, compared positionally.
+    s.sensor("Greet {word}:", |_ctx: Ctx, name: String, _doc: String| {
+        let greeting = format!("Hello, {name}!\n");
+        Ok((name, greeting))
     });
 }

--- a/examples/rust-cargotest/src/steps/yahtzee.rs
+++ b/examples/rust-cargotest/src/steps/yahtzee.rs
@@ -1,15 +1,16 @@
-use super::{as_str, smap, vmap};
+use super::Ctx;
 use crate::yahtzee_example::score;
-use varar::{Steps, Value};
+use std::collections::BTreeMap;
+use varar::Steps;
 
-pub fn register(s: &mut Steps) {
-    s.sensor("Examples of dice, category and score", |_state, row| {
-        let m = smap(&row);
-        let dice: Vec<i64> = as_str(&m["dice"])
+pub fn register(s: &mut Steps<Ctx>) {
+    // Header-bound row: the row arrives keyed by column, and the computed
+    // columns go back the same way for the core to diff cell by cell.
+    s.sensor("Examples of dice, category and score", |_ctx: Ctx, row: BTreeMap<String, String>| {
+        let dice: Vec<i64> = row["dice"]
             .split(',')
             .map(|d| d.trim().parse().expect("die"))
             .collect();
-        let category = as_str(&m["category"]);
-        Ok(Some(vmap(vec![("score", Value::Int(score(&dice, &category)))])))
+        Ok(BTreeMap::from([("score".to_string(), score(&dice, &row["category"]).to_string())]))
     });
 }

--- a/rust/cargotest/src/lib.rs
+++ b/rust/cargotest/src/lib.rs
@@ -20,13 +20,14 @@
 //! ```
 #![allow(clippy::result_large_err)]
 
+use std::any::Any;
 use std::path::Path;
+use std::rc::Rc;
 
 use libtest_mimic::{Arguments, Failed, Trial};
 use varar_core::drift::{self, reconcile_drift};
 use varar_core::parse::parse;
 use varar_core::registry::Registry;
-use varar_core::value::Value;
 use varar_runner::{
     FileBaselineStore, example_names, find_specs, plan_spec, render_failure, run_example,
 };
@@ -34,7 +35,7 @@ use varar_runner::{
 /// Build a registry (`fn`, not a closure — must be `Send + Copy`).
 pub type BuildRegistry = fn() -> Registry;
 /// Map a step file to its fresh initial state.
-pub type ContextFactory = fn(&str) -> Value;
+pub type ContextFactory = fn(&str) -> Rc<dyn Any>;
 
 /// Re-derive and run one example by index. This is what each example `Trial`
 /// closure calls; kept public so it is unit-testable.

--- a/rust/cargotest/tests/adapter.rs
+++ b/rust/cargotest/tests/adapter.rs
@@ -1,6 +1,8 @@
 //! Unit tests for the adapter's per-example runner (the libtest binding itself
 //! is exercised end-to-end by the sample project in examples/rust-cargotest).
 
+use std::any::Any;
+use std::rc::Rc;
 use varar_cargotest::run_one;
 use varar_core::handler::Handler;
 use varar_core::registry::{Registry, add_step, create_registry};
@@ -19,8 +21,8 @@ fn build_registry() -> Registry {
     .unwrap()
 }
 
-fn context(_file: &str) -> Value {
-    Value::Null
+fn context(_file: &str) -> Rc<dyn Any> {
+    Rc::new(Value::Null) as Rc<dyn Any>
 }
 
 #[test]

--- a/rust/core/src/conformance.rs
+++ b/rust/core/src/conformance.rs
@@ -14,6 +14,7 @@ use crate::plan::{ExecutionPlan, PlannedExample, PlannedStep, plan};
 use crate::registry::Registry;
 use crate::span::Span;
 use crate::value::Value;
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -410,7 +411,7 @@ fn file_stem(path: &str) -> String {
 pub fn run_conformance(
     doc: &VarDoc,
     registry: &Registry,
-    context_factory: &dyn Fn() -> Value,
+    context_factory: &dyn Fn() -> Rc<dyn Any>,
 ) -> BundleArtifacts {
     let execution = plan(doc, registry);
 

--- a/rust/core/src/execute.rs
+++ b/rust/core/src/execute.rs
@@ -9,17 +9,19 @@ use crate::diagnostics::Diagnostic;
 use crate::doc_string_diff::compare_doc_string;
 use crate::error::{FailureLocation, HandlerError, StepError, StepFailure};
 use crate::failure_anchor;
-use crate::handler::{Handler, StepReturn};
+use crate::handler::{Handler, StepOutput, StepReturn};
 use crate::offsets::{utf16_len, utf16_slice};
 use crate::param_diff::compare_params_with_formats;
 use crate::plan::{ExecutionPlan, PlannedExample, PlannedStep};
 use crate::step_kind::StepKind;
 use crate::value::Value;
+use std::any::Any;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::Once;
 use std::task::{Context, Poll, Wake, Waker};
 
@@ -52,7 +54,7 @@ pub struct StepObservation {
 }
 
 /// The ports [`collect_examples`]/[`execute_plan`] need. `create_context` maps a
-/// step-file to its fresh initial state (`None` → [`Value::Null`] per file);
+/// step-file to its fresh initial state (`None` → a unit state per file);
 /// `observer` is optional per-step instrumentation. The lifetime lets the port
 /// closures borrow caller locals (e.g. a conformance observer's accumulator).
 pub struct ExecutePorts<'a> {
@@ -64,7 +66,7 @@ pub struct ExecutePorts<'a> {
 /// Receives every diagnostic collected during planning.
 pub type Reporter<'a> = Box<dyn Fn(&Diagnostic) + 'a>;
 /// Maps a step-file to its fresh initial state.
-pub type ContextFactory<'a> = Box<dyn Fn(&str) -> Value + 'a>;
+pub type ContextFactory<'a> = Box<dyn Fn(&str) -> Rc<dyn Any> + 'a>;
 /// Per-step instrumentation (conformance trace mode).
 pub type Observer<'a> = Box<dyn Fn(StepObservation) + 'a>;
 
@@ -144,7 +146,7 @@ fn run_example(
     let source = &plan.var_doc.source;
     let steps = &ex.steps;
 
-    let mut state_by_file: HashMap<String, Value> = HashMap::new();
+    let mut state_by_file: HashMap<String, Rc<dyn Any>> = HashMap::new();
     let mut last_return: Option<Value> = None;
     let mut thrown: Option<StepFailure> = None;
 
@@ -170,17 +172,25 @@ fn run_example(
         let step_error: Option<StepError> =
             match invoke_resolve(&step.step_def.handler, state, call_args) {
                 Err(he) => Some(StepError::Handler(he)),
-                Ok(returned) => {
-                    last_return = returned.clone();
+                Ok(output) => {
+                    last_return = output.compared().cloned();
                     match step.step_def.kind {
                         Some(StepKind::Stimulus) => {
-                            state_by_file.insert(file.clone(), returned.unwrap_or(Value::Null));
+                            // A stimulus's output IS the next state. The facade
+                            // yields `State`; the core's Value-state
+                            // conveniences yield `Compared`, which for a
+                            // stimulus means the same thing.
+                            let next: Rc<dyn Any> = match output {
+                                StepOutput::State(next) => next,
+                                StepOutput::Compared(v) => Rc::new(v.unwrap_or(Value::Null)),
+                            };
+                            state_by_file.insert(file.clone(), next);
                             None
                         }
                         Some(StepKind::Sensor) => {
                             // Header-bound rows are checked after the loop via row_checks.
                             if ex.row_checks.is_none() {
-                                check_sensor_return(source, step, returned).err()
+                                check_sensor_return(source, step, output.compared().cloned()).err()
                             } else {
                                 None
                             }
@@ -269,10 +279,10 @@ fn run_example(
     }
 }
 
-fn create_context(ports: &ExecutePorts, file: &str) -> Value {
+fn create_context(ports: &ExecutePorts, file: &str) -> Rc<dyn Any> {
     match &ports.create_context {
         Some(cc) => cc(file),
-        None => Value::Null,
+        None => Rc::new(()) as Rc<dyn Any>,
     }
 }
 
@@ -437,9 +447,9 @@ fn install_hook() {
 /// assertion-style failure channel) into a [`HandlerError`].
 fn invoke_resolve(
     handler: &Handler,
-    state: Value,
+    state: Rc<dyn Any>,
     args: Vec<Value>,
-) -> Result<Option<Value>, HandlerError> {
+) -> Result<StepOutput, HandlerError> {
     install_hook();
     let caught = SUPPRESS_PANIC.with(|s| {
         s.set(true);

--- a/rust/core/src/handler.rs
+++ b/rust/core/src/handler.rs
@@ -6,13 +6,33 @@
 
 use crate::error::HandlerError;
 use crate::value::Value;
+use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 
 /// A handler's resolved return: `Ok(None)` = "no assertion" (Java `null`),
 /// `Ok(Some(v))` = a value, `Err(_)` = an author-signalled failure (Java `throw`).
-pub type HandlerReturn = Result<Option<Value>, HandlerError>;
+pub type HandlerReturn = Result<StepOutput, HandlerError>;
+
+/// What a handler produced. A stimulus yields the whole next state, which is
+/// **opaque to the core** — it is threaded between a file's steps and replaced
+/// wholesale, never compared, serialized, or inspected. A sensor yields the
+/// value to compare against the document (`None` = no assertion).
+pub enum StepOutput {
+    State(Rc<dyn Any>),
+    Compared(Option<Value>),
+}
+
+impl StepOutput {
+    /// The comparison value, or `None` for a state output.
+    pub fn compared(&self) -> Option<&Value> {
+        match self {
+            StepOutput::Compared(v) => v.as_ref(),
+            StepOutput::State(_) => None,
+        }
+    }
+}
 
 /// The sync-or-async return channel.
 pub enum StepReturn {
@@ -20,65 +40,87 @@ pub enum StepReturn {
     Pending(Pin<Box<dyn Future<Output = HandlerReturn>>>),
 }
 
+/// Reads an opaque state back as a [`Value`], defaulting to `Null`.
+fn value_state(state: &Rc<dyn Any>) -> Value {
+    state
+        .downcast_ref::<Value>()
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+/// The boxed closure a [`Handler`] wraps: the opaque state plus the slot
+/// arguments, in slot order.
+type HandlerFn = dyn Fn(Rc<dyn Any>, Vec<Value>) -> StepReturn;
+
 /// A registered step handler: a closure over `(state, args_after_state)`.
 #[derive(Clone)]
 pub struct Handler {
-    f: Rc<dyn Fn(Value, Vec<Value>) -> StepReturn>,
+    f: Rc<HandlerFn>,
 }
 
 impl Handler {
     /// A no-op handler (arity-agnostic) — used where a handler is never invoked.
     pub fn noop() -> Handler {
         Handler {
-            f: Rc::new(|_state, _args| StepReturn::Ready(Ok(None))),
+            f: Rc::new(|_state, _args| StepReturn::Ready(Ok(StepOutput::Compared(None)))),
         }
     }
 
-    /// A synchronous 0-argument handler `(state)`.
-    pub fn sync0(f: impl Fn(Value) -> HandlerReturn + 'static) -> Handler {
+    /// Builds a handler from a raw closure over the opaque state and the slot
+    /// arguments. The facade's typed `stimulus`/`sensor` build these; authors
+    /// use those instead.
+    pub fn new(f: impl Fn(Rc<dyn Any>, Vec<Value>) -> HandlerReturn + 'static) -> Handler {
         Handler {
-            f: Rc::new(move |state, args| {
-                if !args.is_empty() {
-                    return StepReturn::Ready(Err(HandlerError::new(
-                        "no handler with 0 parameter(s)",
-                    )));
-                }
-                StepReturn::Ready(f(state))
-            }),
+            f: Rc::new(move |state, args| StepReturn::Ready(f(state, args))),
         }
+    }
+
+    /// Fixed-arity conveniences over a [`Value`] state. These exist for the
+    /// core's own tests and for any consumer not using the `varar` facade —
+    /// the facade builds handlers from typed closures instead, so an author
+    /// never calls these.
+    pub fn sync0(f: impl Fn(Value) -> Result<Option<Value>, HandlerError> + 'static) -> Handler {
+        Handler::new(move |state, args| {
+            if !args.is_empty() {
+                return Err(HandlerError::new("no handler with 0 parameter(s)"));
+            }
+            Ok(StepOutput::Compared(f(value_state(&state))?))
+        })
     }
 
     /// A synchronous 1-argument handler `(state, a)`.
-    pub fn sync1(f: impl Fn(Value, Value) -> HandlerReturn + 'static) -> Handler {
-        Handler {
-            f: Rc::new(move |state, args| {
-                if args.len() != 1 {
-                    return StepReturn::Ready(Err(HandlerError::new(
-                        "no handler with 1 parameter(s)",
-                    )));
-                }
-                let mut it = args.into_iter();
-                let a = it.next().unwrap();
-                StepReturn::Ready(f(state, a))
-            }),
-        }
+    pub fn sync1(
+        f: impl Fn(Value, Value) -> Result<Option<Value>, HandlerError> + 'static,
+    ) -> Handler {
+        Handler::new(move |state, args| {
+            if args.len() != 1 {
+                return Err(HandlerError::new("no handler with 1 parameter(s)"));
+            }
+            Ok(StepOutput::Compared(f(value_state(&state), args[0].clone())?))
+        })
     }
 
     /// A synchronous 2-argument handler `(state, a, b)`.
-    pub fn sync2(f: impl Fn(Value, Value, Value) -> HandlerReturn + 'static) -> Handler {
-        Handler {
-            f: Rc::new(move |state, args| {
-                if args.len() != 2 {
-                    return StepReturn::Ready(Err(HandlerError::new(
-                        "no handler with 2 parameter(s)",
-                    )));
-                }
-                let mut it = args.into_iter();
-                let a = it.next().unwrap();
-                let b = it.next().unwrap();
-                StepReturn::Ready(f(state, a, b))
-            }),
-        }
+    pub fn sync2(
+        f: impl Fn(Value, Value, Value) -> Result<Option<Value>, HandlerError> + 'static,
+    ) -> Handler {
+        Handler::new(move |state, args| {
+            if args.len() != 2 {
+                return Err(HandlerError::new("no handler with 2 parameter(s)"));
+            }
+            Ok(StepOutput::Compared(f(value_state(&state), args[0].clone(), args[1].clone())?))
+        })
+    }
+
+    /// As [`Handler::sync1`], but its result is the next state rather than a
+    /// value to compare.
+    pub fn state1(f: impl Fn(Value, Value) -> Result<Value, HandlerError> + 'static) -> Handler {
+        Handler::new(move |state, args| {
+            if args.len() != 1 {
+                return Err(HandlerError::new("no handler with 1 parameter(s)"));
+            }
+            Ok(StepOutput::State(Rc::new(f(value_state(&state), args[0].clone())?)))
+        })
     }
 
     /// An asynchronous 0-argument handler returning a `Future`.
@@ -92,34 +134,29 @@ impl Handler {
                         "no handler with 0 parameter(s)",
                     )));
                 }
-                StepReturn::Pending(f(state))
+                StepReturn::Pending(f(value_state(&state)))
             }),
         }
     }
 
-    /// A synchronous handler of any arity: `(state, args)` where `args` holds
-    /// every capture plus the trailing table/doc string, in slot order. The
-    /// general escape hatch matching Java's reflective any-arity invocation and
-    /// Python's `*args` — use it for steps with three or more slots, where the
-    /// fixed-arity conveniences above stop.
-    pub fn sync_var(f: impl Fn(Value, Vec<Value>) -> HandlerReturn + 'static) -> Handler {
-        Handler {
-            f: Rc::new(move |state, args| StepReturn::Ready(f(state, args))),
-        }
+    /// A synchronous handler of any arity: `(state, args)`.
+    pub fn sync_var(
+        f: impl Fn(Value, Vec<Value>) -> Result<Option<Value>, HandlerError> + 'static,
+    ) -> Handler {
+        Handler::new(move |state, args| Ok(StepOutput::Compared(f(value_state(&state), args)?)))
     }
 
-    /// As [`Handler::sync_var`], returning a `Future` — the any-arity async form
-    /// (an async handler with parameters is inexpressible via [`Handler::async0`]).
+    /// As [`Handler::sync_var`], returning a `Future`.
     pub fn async_var(
         f: impl Fn(Value, Vec<Value>) -> Pin<Box<dyn Future<Output = HandlerReturn>>> + 'static,
     ) -> Handler {
         Handler {
-            f: Rc::new(move |state, args| StepReturn::Pending(f(state, args))),
+            f: Rc::new(move |state, args| StepReturn::Pending(f(value_state(&state), args))),
         }
     }
 
     /// Invokes the handler with `state` + `args` (captures then trailing attachment).
-    pub(crate) fn call(&self, state: Value, args: Vec<Value>) -> StepReturn {
+    pub(crate) fn call(&self, state: Rc<dyn Any>, args: Vec<Value>) -> StepReturn {
         (self.f)(state, args)
     }
 }

--- a/rust/core/tests/execute_test.rs
+++ b/rust/core/tests/execute_test.rs
@@ -9,6 +9,7 @@
 mod common;
 
 use common::vmap;
+use std::any::Any;
 use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
@@ -20,13 +21,15 @@ use varar_core::execute::{
     ExecutePorts, StepObservation, StepOutcome, collect_examples, execute_plan,
 };
 use varar_core::failure::to_failure;
-use varar_core::handler::{Handler, HandlerReturn};
+use varar_core::handler::{Handler, HandlerReturn, StepOutput};
 use varar_core::offsets::utf16_slice;
 use varar_core::parse::parse;
 use varar_core::plan::{ExecutionPlan, plan};
 use varar_core::registry::{Registry, add_step, create_registry};
 use varar_core::step_kind::StepKind;
 use varar_core::value::Value;
+
+type ContextFactory<'a> = varar_core::execute::ContextFactory<'a>;
 
 fn int_of(v: &Value) -> i64 {
     match v {
@@ -146,7 +149,7 @@ fn threads_full_replacement_state_and_sensor_compares_return_against_last_captur
     let p = plan_of("# Adding\n\nI add 5. I add 3. the total is 8.", &r);
     let ports = ExecutePorts {
         reporter: Box::new(|_| {}),
-        create_context: Some(Box::new(|_| Value::Int(0))),
+        create_context: Some(Box::new(|_| Rc::new(Value::Int(0)) as Rc<dyn Any>)),
         observer: None,
     };
     let queued = collect_examples(&p, &ports);
@@ -289,9 +292,9 @@ fn create_context_is_called_fresh_once_per_example() {
     let p = plan_of("# A\n\nI record ctx\n\n# B\n\nI record ctx", &r);
     let calls = Rc::new(RefCell::new(0));
     let calls2 = calls.clone();
-    let create = Box::new(move |_file: &str| {
+    let create: ContextFactory = Box::new(move |_file: &str| {
         *calls2.borrow_mut() += 1;
-        Value::from(format!("init{}", calls2.borrow()))
+        Rc::new(Value::from(format!("init{}", calls2.borrow()))) as Rc<dyn Any>
     });
     let ports = ExecutePorts {
         reporter: Box::new(|_| {}),
@@ -334,9 +337,9 @@ fn state_is_threaded_across_steps_sharing_the_same_file_no_new_context_per_step(
     let p = plan_of("# A\n\nI seed\nI record ctx", &r);
     let calls = Rc::new(RefCell::new(0));
     let calls2 = calls.clone();
-    let create = Box::new(move |_file: &str| {
+    let create: ContextFactory = Box::new(move |_file: &str| {
         *calls2.borrow_mut() += 1;
-        Value::from("unseeded")
+        Rc::new(Value::from("unseeded")) as Rc<dyn Any>
     });
     let ports = ExecutePorts {
         reporter: Box::new(|_| {}),
@@ -828,7 +831,7 @@ fn an_action_handler_returning_a_future_is_awaited_and_its_result_becomes_the_ne
         1,
         Handler::async0(|_state| {
             Box::pin(YieldOnce {
-                value: Some(Ok(Some(Value::from("hi")))),
+                value: Some(Ok(StepOutput::Compared(Some(Value::from("hi"))))),
                 yielded: false,
             })
         }),
@@ -994,7 +997,7 @@ fn an_async_handler_with_parameters_runs_through_async_var() {
                     Value::String(s) => s.clone(),
                     _ => String::new(),
                 };
-                Ok(Some(Value::from(format!("hi {name}"))))
+                Ok(StepOutput::Compared(Some(Value::from(format!("hi {name}")))))
             })
         }),
         Some(StepKind::Stimulus),

--- a/rust/runner/src/run.rs
+++ b/rust/runner/src/run.rs
@@ -1,12 +1,13 @@
 //! Planning and running examples, plus the adapter display-name rule.
 
+use std::any::Any;
 use std::collections::HashMap;
+use std::rc::Rc;
 use varar_core::error::StepFailure;
 use varar_core::execute::{ExecutePorts, collect_examples};
 use varar_core::parse::parse;
 use varar_core::plan::{ExecutionPlan, plan};
 use varar_core::registry::Registry;
-use varar_core::value::Value;
 
 /// Parse + plan one spec.
 pub fn plan_spec(name: &str, source: &str, registry: &Registry) -> ExecutionPlan {
@@ -42,7 +43,7 @@ pub fn example_names(plan: &ExecutionPlan) -> Vec<String> {
 /// fresh initial state.
 pub fn run_example(
     plan: &ExecutionPlan,
-    context_factory: &dyn Fn(&str) -> Value,
+    context_factory: &dyn Fn(&str) -> Rc<dyn Any>,
     index: usize,
 ) -> Result<(), StepFailure> {
     let ports = ExecutePorts {

--- a/rust/varar/src/lib.rs
+++ b/rust/varar/src/lib.rs
@@ -1,23 +1,29 @@
 //! `varar` — the author facade over [`varar_core`].
 //!
 //! Rust uses the **injected-Registrar** author model (ADR 0006): a step file
-//! exposes a `register(Registry) -> Registry` that adds its steps explicitly,
-//! rather than the module-scope accumulator TypeScript/Python use. There is
-//! therefore no `defineState`/`steps()` side-effecting global here — the
-//! "author API" is `varar_core::registry` plus the handler/value types, curated
-//! into a single import surface. This crate is also where the
+//! exposes a `register(&mut Steps<C>)` that adds its steps explicitly, rather
+//! than the module-scope accumulator TypeScript/Python use. There is therefore
+//! no `defineState`/`steps()` side-effecting global here.
+//!
+//! The surface is deliberately small: [`Steps`] is generic in **your** context
+//! type, slots arrive as **your** Rust types, and a sensor returns one value per
+//! slot. The core's dynamic `Value` is an escape hatch, not the way you write
+//! steps. This crate is also where the
 //! registry/plan/trace conformance gates live (see `tests/conformance.rs`),
 //! mirroring the Java `var` module: they need both `varar-core`'s pipeline and
 //! the author surface every bundle fixture is written against.
 
 mod steps;
-pub use steps::{IntoHandler, Steps};
+mod value_conv;
+
+pub use steps::{IntoSensor, IntoStimulus, Steps};
+pub use value_conv::{FromSlot, ToSlot};
 
 pub use varar_core::error::HandlerError;
-pub use varar_core::handler::{Handler, HandlerReturn, StepReturn};
-pub use varar_core::registry::{
-    CustomParameterType, FormatFn, ParseFn, Registry, StepRegistration, add_step, create_registry,
-    define_parameter_type, define_parameter_type_with_format,
-};
-pub use varar_core::step_kind::StepKind;
+pub use varar_core::registry::Registry;
+
+// `Value` is the core's wire model, not part of the authoring surface: slots
+// arrive as your own Rust types (see `FromSlot`), the context is your own type,
+// and a sensor returns its slots' types. It is re-exported only as the escape
+// hatch for a slot with no natural Rust spelling.
 pub use varar_core::value::Value;

--- a/rust/varar/src/steps.rs
+++ b/rust/varar/src/steps.rs
@@ -1,130 +1,302 @@
-//! The ergonomic author API: a `Steps` builder over `varar-core`'s registry, so
-//! step definitions read as `s.stimulus(expr, …)` / `s.sensor(expr, …)` — the
-//! call name IS the kind, matching every other port (and what the LSP/
-//! tree-sitter dialect extracts). Mirrors the JVM `StateBinder`.
+//! The author API: a `Steps<C>` builder over `varar-core`'s registry, generic in
+//! **C — your own context type**. Step definitions read as
+//! `s.stimulus(expr, …)` / `s.sensor(expr, …)`; the call name IS the kind,
+//! matching every other port (and what the LSP/tree-sitter dialect extracts).
 //!
-//! The builder owns a `Registry` and folds each definition in with `varar-core`'s
-//! pure `add_step` / `define_parameter_type*`; nothing global is mutated.
+//! Nothing here mentions `Value`. A step's slots arrive as the Rust types the
+//! handler declares ([`FromSlot`]), the state is your `C`, and a sensor returns
+//! one value per slot — the same contract every port shares. TypeScript spells
+//! the two-slot return as the tuple `[n, n * n]`; Rust spells it as `(n, n * n)`:
+//!
+//! ```ignore
+//! struct Ctx { total: i64 }
+//!
+//! pub fn register(s: &mut Steps<Ctx>) {
+//!     s.stimulus("I add {int}", |ctx: Ctx, n: i64| Ok(Ctx { total: ctx.total + n }));
+//!     s.sensor("The square of {int} is {int}.", |_ctx: Ctx, n: i64, _sq: i64| Ok((n, n * n)));
+//! }
+//! ```
+//!
+//! Unlike Go's reflective equivalent, every one of these is checked by the
+//! compiler: a wrong arity, a slot type that cannot be read, or a sensor whose
+//! results do not match its slots is a build error, not a run-time one.
 
-use varar_core::handler::{Handler, HandlerReturn};
+use std::any::Any;
+use std::rc::Rc;
+
+use varar_core::error::HandlerError;
+use varar_core::handler::{Handler, StepOutput};
 use varar_core::registry::{
-    FormatFn, ParseFn, Registry, add_step, create_registry, define_parameter_type,
-    define_parameter_type_with_format,
+    Registry, add_step, create_registry, define_parameter_type, define_parameter_type_with_format,
 };
 use varar_core::step_kind::StepKind;
 use varar_core::value::Value;
 
-/// Converts an author's bare closure into a [`Handler`], inferring the arity —
-/// and thus each `Value` parameter — from the closure itself. This is what lets
-/// step files read `s.sensor("…", |state, a| …)` with no `Handler::sync1`
-/// wrapper: `sensor`/`stimulus` take `impl IntoHandler<A>`, and the compiler
-/// selects the impl whose `Fn` arity matches the closure.
-///
-/// `Args` is an inference-only marker — the tuple of the closure's *capture*
-/// parameters (everything after the leading `state`) — following the axum/bevy
-/// handler pattern; it never appears in author code. Impls cover 0–2 captures,
-/// matching the fixed-arity `Handler::sync{0,1,2}` conveniences. For a dynamic
-/// arity (3+ slots) or an async handler, build the [`Handler`] explicitly
-/// (`Handler::sync_var`, `Handler::async0`, …) and pass it — the passthrough
-/// impl accepts an already-built `Handler` unchanged (also how `Handler::noop`
-/// is passed).
-pub trait IntoHandler<Args> {
+use crate::value_conv::{FromSlot, ToSlot};
+
+/// Reads the opaque state back as `C`, falling back to `C::default()` on the
+/// first step of a file (when no context factory supplied one).
+fn state_as<C: Clone + Default + 'static>(state: &Rc<dyn Any>) -> C {
+    state
+        .downcast_ref::<C>()
+        .cloned()
+        .unwrap_or_else(C::default)
+}
+
+fn slot<T: FromSlot>(args: &[Value], i: usize) -> Result<T, HandlerError> {
+    let value = args
+        .get(i)
+        .ok_or_else(|| HandlerError::new(format!("this step has no slot {}", i + 1)))?;
+    T::from_slot(value)
+}
+
+fn arity(args: &[Value], want: usize) -> Result<(), HandlerError> {
+    if args.len() != want {
+        return Err(HandlerError::new(format!(
+            "this step has {} slot(s), but the handler takes {want}",
+            args.len()
+        )));
+    }
+    Ok(())
+}
+
+/// A closure that can register as a stimulus for context `C`. `Args` is an
+/// inference-only marker (the tuple of slot types), following the axum/bevy
+/// handler pattern; it never appears in author code.
+pub trait IntoStimulus<C, Args> {
     fn into_handler(self) -> Handler;
 }
 
-impl<F: Fn(Value) -> HandlerReturn + 'static> IntoHandler<()> for F {
-    fn into_handler(self) -> Handler {
-        Handler::sync0(self)
-    }
+/// A closure that can register as a sensor for context `C`.
+pub trait IntoSensor<C, Args> {
+    fn into_handler(self) -> Handler;
 }
-impl<F: Fn(Value, Value) -> HandlerReturn + 'static> IntoHandler<(Value,)> for F {
+
+/// Inference-only marker for a sensor that asserts for itself (returns `()`)
+/// instead of returning its slots for the core to compare — the opt-out a
+/// greedy capture sometimes needs, e.g. `{word}` swallowing trailing
+/// punctuation. Never written in author code.
+pub struct Asserted<Args>(std::marker::PhantomData<Args>);
+
+// --- stimuli: (C, slots…) -> Result<C> --------------------------------------
+
+impl<C, F> IntoStimulus<C, ()> for F
+where
+    C: Clone + Default + 'static,
+    F: Fn(C) -> Result<C, HandlerError> + 'static,
+{
     fn into_handler(self) -> Handler {
-        Handler::sync1(self)
-    }
-}
-impl<F: Fn(Value, Value, Value) -> HandlerReturn + 'static> IntoHandler<(Value, Value)> for F {
-    fn into_handler(self) -> Handler {
-        Handler::sync2(self)
-    }
-}
-impl IntoHandler<Handler> for Handler {
-    fn into_handler(self) -> Handler {
-        self
+        Handler::new(move |state, args| {
+            arity(&args, 0)?;
+            Ok(StepOutput::State(Rc::new(self(state_as::<C>(&state))?)))
+        })
     }
 }
 
-pub struct Steps {
+impl<C, A, F> IntoStimulus<C, (A,)> for F
+where
+    C: Clone + Default + 'static,
+    A: FromSlot,
+    F: Fn(C, A) -> Result<C, HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 1)?;
+            let a = slot::<A>(&args, 0)?;
+            Ok(StepOutput::State(Rc::new(self(state_as::<C>(&state), a)?)))
+        })
+    }
+}
+
+impl<C, A, B, F> IntoStimulus<C, (A, B)> for F
+where
+    C: Clone + Default + 'static,
+    A: FromSlot,
+    B: FromSlot,
+    F: Fn(C, A, B) -> Result<C, HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 2)?;
+            let (a, b) = (slot::<A>(&args, 0)?, slot::<B>(&args, 1)?);
+            Ok(StepOutput::State(Rc::new(self(state_as::<C>(&state), a, b)?)))
+        })
+    }
+}
+
+// --- sensors: (C, slots…) -> Result<slots…> ---------------------------------
+
+impl<C, F> IntoSensor<C, ()> for F
+where
+    C: Clone + Default + 'static,
+    F: Fn(C) -> Result<(), HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 0)?;
+            self(state_as::<C>(&state))?;
+            Ok(StepOutput::Compared(None))
+        })
+    }
+}
+
+impl<C, A, F> IntoSensor<C, (A,)> for F
+where
+    C: Clone + Default + 'static,
+    A: FromSlot + ToSlot,
+    F: Fn(C, A) -> Result<A, HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 1)?;
+            let a = slot::<A>(&args, 0)?;
+            // One slot: the return IS that slot's value, never a list.
+            let got = self(state_as::<C>(&state), a)?;
+            Ok(StepOutput::Compared(Some(got.to_slot())))
+        })
+    }
+}
+
+impl<C, A, F> IntoSensor<C, Asserted<(A,)>> for F
+where
+    C: Clone + Default + 'static,
+    A: FromSlot,
+    F: Fn(C, A) -> Result<(), HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 1)?;
+            let a = slot::<A>(&args, 0)?;
+            self(state_as::<C>(&state), a)?;
+            Ok(StepOutput::Compared(None))
+        })
+    }
+}
+
+impl<C, A, B, F> IntoSensor<C, Asserted<(A, B)>> for F
+where
+    C: Clone + Default + 'static,
+    A: FromSlot,
+    B: FromSlot,
+    F: Fn(C, A, B) -> Result<(), HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 2)?;
+            let (a, b) = (slot::<A>(&args, 0)?, slot::<B>(&args, 1)?);
+            self(state_as::<C>(&state), a, b)?;
+            Ok(StepOutput::Compared(None))
+        })
+    }
+}
+
+impl<C, A, B, F> IntoSensor<C, (A, B)> for F
+where
+    C: Clone + Default + 'static,
+    A: FromSlot + ToSlot,
+    B: FromSlot + ToSlot,
+    F: Fn(C, A, B) -> Result<(A, B), HandlerError> + 'static,
+{
+    fn into_handler(self) -> Handler {
+        Handler::new(move |state, args| {
+            arity(&args, 2)?;
+            let (a, b) = (slot::<A>(&args, 0)?, slot::<B>(&args, 1)?);
+            let (ga, gb) = self(state_as::<C>(&state), a, b)?;
+            Ok(StepOutput::Compared(Some(Value::List(vec![ga.to_slot(), gb.to_slot()]))))
+        })
+    }
+}
+
+/// Renders a parameter type's value back in the document's notation, for the
+/// diff shown when a sensor mismatches.
+pub type Format<T> = Box<dyn Fn(&T) -> String>;
+
+/// The step builder, generic in the context type `C`.
+pub struct Steps<C> {
     registry: Registry,
+    _context: std::marker::PhantomData<C>,
 }
 
-impl Steps {
+impl<C: Clone + Default + 'static> Steps<C> {
     /// A builder over a fresh registry.
-    pub fn new() -> Steps {
-        Steps {
-            registry: create_registry(),
-        }
+    pub fn new() -> Steps<C> {
+        Steps::from_registry(create_registry())
     }
 
     /// A builder that continues folding into an existing registry.
-    pub fn from_registry(registry: Registry) -> Steps {
-        Steps { registry }
+    pub fn from_registry(registry: Registry) -> Steps<C> {
+        Steps {
+            registry,
+            _context: std::marker::PhantomData,
+        }
     }
 
-    /// Register a stimulus (drives the software; returns the whole next state).
-    ///
-    /// The step's source file and line are captured automatically from the
-    /// call site via `#[track_caller]` — the Rust analogue of how the TS/Python
-    /// ports read them from the imported module. Authors never pass them; the
-    /// captured file's stem (e.g. `numerals.steps`) is what the registry and
-    /// conformance artifacts record.
+    /// Register a stimulus: it drives the software and returns the whole next
+    /// context. Source file and line are captured from the call site, so authors
+    /// never pass them.
     #[track_caller]
-    pub fn stimulus<A>(&mut self, expression: &str, handler: impl IntoHandler<A>) -> &mut Steps {
+    pub fn stimulus<Args>(
+        &mut self,
+        expression: &str,
+        handler: impl IntoStimulus<C, Args>,
+    ) -> &mut Steps<C> {
         let loc = std::panic::Location::caller();
+        self.add(expression, loc, handler.into_handler(), StepKind::Stimulus)
+    }
+
+    /// Register a sensor: the read-only assertion, returning one value per slot
+    /// for the core to compare against the document.
+    #[track_caller]
+    pub fn sensor<Args>(
+        &mut self,
+        expression: &str,
+        handler: impl IntoSensor<C, Args>,
+    ) -> &mut Steps<C> {
+        let loc = std::panic::Location::caller();
+        self.add(expression, loc, handler.into_handler(), StepKind::Sensor)
+    }
+
+    fn add(
+        &mut self,
+        expression: &str,
+        loc: &std::panic::Location<'_>,
+        handler: Handler,
+        kind: StepKind,
+    ) -> &mut Steps<C> {
         self.registry = add_step(
             &self.registry,
             expression,
             loc.file(),
             loc.line() as usize,
-            handler.into_handler(),
-            Some(StepKind::Stimulus),
+            handler,
+            Some(kind),
         )
-        .expect("valid stimulus expression");
+        .expect("valid step expression");
         self
     }
 
-    /// Register a sensor (the read-only assertion; its return is compared).
-    ///
-    /// Source file and line are captured from the call site, same as
-    /// [`Steps::stimulus`].
-    #[track_caller]
-    pub fn sensor<A>(&mut self, expression: &str, handler: impl IntoHandler<A>) -> &mut Steps {
-        let loc = std::panic::Location::caller();
-        self.registry = add_step(
-            &self.registry,
-            expression,
-            loc.file(),
-            loc.line() as usize,
-            handler.into_handler(),
-            Some(StepKind::Sensor),
-        )
-        .expect("valid sensor expression");
-        self
-    }
-
-    /// Declare a custom parameter type. Pass `Some(format)` to also render values for diffs,
-    /// or `None` for none — the single `param` shape every port shares.
-    pub fn param(
+    /// Declare a custom parameter type in terms of your own Rust type: `parse`
+    /// turns the regexp's capture groups into a `T`, which then arrives directly
+    /// as the step's slot. Pass `Some(format)` to render a `T` back in the
+    /// document's notation when a mismatch is reported.
+    pub fn param<T: FromSlot + ToSlot + 'static>(
         &mut self,
         name: &str,
         regexp: &str,
-        parse: ParseFn,
-        format: Option<FormatFn>,
-    ) -> &mut Steps {
+        parse: impl Fn(&[&str]) -> T + 'static,
+        format: Option<Format<T>>,
+    ) -> &mut Steps<C> {
+        let parse_fn: varar_core::registry::ParseFn =
+            Rc::new(move |groups: &[&str]| parse(groups).to_slot());
         self.registry = match format {
-            Some(format) => {
-                define_parameter_type_with_format(&self.registry, name, regexp, parse, format)
-            }
-            None => define_parameter_type(&self.registry, name, regexp, parse),
+            Some(format) => define_parameter_type_with_format(
+                &self.registry,
+                name,
+                regexp,
+                parse_fn,
+                Rc::new(move |v: &Value| T::from_slot(v).ok().map(|t| format(&t))),
+            ),
+            None => define_parameter_type(&self.registry, name, regexp, parse_fn),
         };
         self
     }
@@ -135,8 +307,8 @@ impl Steps {
     }
 }
 
-impl Default for Steps {
-    fn default() -> Steps {
+impl<C: Clone + Default + 'static> Default for Steps<C> {
+    fn default() -> Steps<C> {
         Steps::new()
     }
 }

--- a/rust/varar/src/value_conv.rs
+++ b/rust/varar/src/value_conv.rs
@@ -1,0 +1,181 @@
+//! Converting between a step's slots and the author's own Rust types.
+//!
+//! A slot is a `Value` inside the core, but an author should never have to say
+//! so: implement [`FromSlot`] to receive your type as a step parameter, and
+//! [`ToSlot`] so a sensor can return it for comparison. The primitives and
+//! `String` are implemented here; a domain type implements the pair once (the
+//! serde-without-derive shape — Rust has no reflection to map structs for you).
+
+use varar_core::error::HandlerError;
+use varar_core::value::Value;
+
+/// A type a step parameter can be read into.
+pub trait FromSlot: Sized {
+    fn from_slot(value: &Value) -> Result<Self, HandlerError>;
+}
+
+/// A type a sensor can return for comparison against the document.
+pub trait ToSlot {
+    fn to_slot(&self) -> Value;
+}
+
+fn mismatch(want: &str, got: &Value) -> HandlerError {
+    HandlerError::new(format!("expected {want}, got {}", got.type_name()))
+}
+
+impl FromSlot for i64 {
+    fn from_slot(value: &Value) -> Result<i64, HandlerError> {
+        match value {
+            Value::Int(i) => Ok(*i),
+            other => Err(mismatch("an integer", other)),
+        }
+    }
+}
+
+impl FromSlot for i32 {
+    fn from_slot(value: &Value) -> Result<i32, HandlerError> {
+        i64::from_slot(value).map(|i| i as i32)
+    }
+}
+
+impl FromSlot for f64 {
+    fn from_slot(value: &Value) -> Result<f64, HandlerError> {
+        match value {
+            Value::Float(f) => Ok(*f),
+            other => Err(mismatch("a number", other)),
+        }
+    }
+}
+
+impl FromSlot for bool {
+    fn from_slot(value: &Value) -> Result<bool, HandlerError> {
+        match value {
+            Value::Bool(b) => Ok(*b),
+            other => Err(mismatch("a boolean", other)),
+        }
+    }
+}
+
+impl FromSlot for String {
+    fn from_slot(value: &Value) -> Result<String, HandlerError> {
+        match value {
+            Value::String(s) => Ok(s.clone()),
+            other => Err(mismatch("a string", other)),
+        }
+    }
+}
+
+/// The escape hatch: a slot with no natural Rust spelling (a whole table, or a
+/// custom parameter type that parses to a map) can still be taken as a `Value`.
+impl FromSlot for Value {
+    fn from_slot(value: &Value) -> Result<Value, HandlerError> {
+        Ok(value.clone())
+    }
+}
+
+/// A whole-table slot: the header row followed by the data rows.
+impl FromSlot for Vec<Vec<String>> {
+    fn from_slot(value: &Value) -> Result<Vec<Vec<String>>, HandlerError> {
+        let Value::List(rows) = value else {
+            return Err(mismatch("a table", value));
+        };
+        rows.iter()
+            .map(|row| {
+                let Value::List(cells) = row else {
+                    return Err(mismatch("a table row", row));
+                };
+                Ok(cells
+                    .iter()
+                    .map(|c| match c {
+                        Value::String(s) => s.clone(),
+                        other => format!("{other:?}"),
+                    })
+                    .collect())
+            })
+            .collect()
+    }
+}
+
+/// A computed table: rows of cells, compared positionally against the input
+/// table's columns.
+impl ToSlot for Vec<Vec<String>> {
+    fn to_slot(&self) -> Value {
+        Value::List(
+            self.iter()
+                .map(|row| Value::List(row.iter().map(|c| Value::String(c.clone())).collect()))
+                .collect(),
+        )
+    }
+}
+
+impl ToSlot for i64 {
+    fn to_slot(&self) -> Value {
+        Value::Int(*self)
+    }
+}
+
+impl ToSlot for i32 {
+    fn to_slot(&self) -> Value {
+        Value::Int(i64::from(*self))
+    }
+}
+
+impl ToSlot for f64 {
+    fn to_slot(&self) -> Value {
+        Value::Float(*self)
+    }
+}
+
+impl ToSlot for bool {
+    fn to_slot(&self) -> Value {
+        Value::Bool(*self)
+    }
+}
+
+impl ToSlot for String {
+    fn to_slot(&self) -> Value {
+        Value::String(self.clone())
+    }
+}
+
+impl ToSlot for &str {
+    fn to_slot(&self) -> Value {
+        Value::String((*self).to_string())
+    }
+}
+
+impl ToSlot for Value {
+    fn to_slot(&self) -> Value {
+        self.clone()
+    }
+}
+
+/// A header-bound row's computed columns, keyed by column name.
+impl ToSlot for std::collections::BTreeMap<String, String> {
+    fn to_slot(&self) -> Value {
+        Value::Map(
+            self.iter()
+                .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+                .collect(),
+        )
+    }
+}
+
+/// A header-bound row as it arrives: the row's cells keyed by column name.
+impl FromSlot for std::collections::BTreeMap<String, String> {
+    fn from_slot(value: &Value) -> Result<Self, HandlerError> {
+        let Value::Map(map) = value else {
+            return Err(mismatch("a row", value));
+        };
+        Ok(map
+            .iter()
+            .map(|(k, v)| {
+                let cell = match v {
+                    Value::String(s) => s.clone(),
+                    other => format!("{other:?}"),
+                };
+                (k.clone(), cell)
+            })
+            .collect())
+    }
+}

--- a/rust/varar/tests/conformance.rs
+++ b/rust/varar/tests/conformance.rs
@@ -13,12 +13,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use varar::{Steps, create_registry};
+use std::any::Any;
+use std::rc::Rc;
+
+use varar::{Registry, Steps};
 use varar_core::canonical_json::canonical_stringify;
 use varar_core::conformance::{run_conformance, to_plan_artifact, to_registry_artifact};
 use varar_core::parse::parse;
 use varar_core::plan::plan;
-use varar_core::value::Value;
 
 // Fixtures live in the shared corpus (siblings of every `*.steps.ts`), pulled
 // in by path. Declared at the test's top level so the path base is
@@ -54,26 +56,38 @@ mod b14;
 #[path = "../../../conformance/bundles/15-custom-parameter-format/money.steps.rs"]
 mod b15;
 
-type RegisterFn = fn(&mut Steps);
-type StateFn = fn() -> Value;
+// Each bundle now has its OWN context type, so the fixtures cannot share one
+// function-pointer type. This macro erases that difference: it builds the
+// bundle's registry with its own `Steps<Ctx>` and boxes its state factory, so
+// every arm yields the same `(Registry, ContextFactory)` pair.
+type ContextFactory = Box<dyn Fn() -> Rc<dyn Any>>;
 
-fn fixture(bundle: &str) -> (RegisterFn, StateFn) {
+macro_rules! bundle {
+    ($m:ident) => {{
+        let mut s = Steps::new();
+        $m::register(&mut s);
+        let factory: ContextFactory = Box::new(|| Rc::new($m::state()) as Rc<dyn Any>);
+        (s.into_registry(), factory)
+    }};
+}
+
+fn fixture(bundle: &str) -> (Registry, ContextFactory) {
     match bundle {
-        "01-roman-numerals" => (b01::register, b01::state),
-        "02-context-isolation" => (b02::register, b02::state),
-        "03-expected-failure" => (b03::register, b03::state),
-        "04-tables-and-docstrings" => (b04::register, b04::state),
-        "05-ambiguous-match" => (b05::register, b05::state),
-        "06-doc-string-mismatch" => (b06::register, b06::state),
-        "07-row-check-mismatch" => (b07::register, b07::state),
-        "08-string-capture" => (b08::register, b08::state),
-        "09-expected-message-mismatch" => (b09::register, b09::state),
-        "10-error-fence-without-step" => (b10::register, b10::state),
-        "11-emoji-offsets" => (b11::register, b11::state),
-        "12-combining-marks" => (b12::register, b12::state),
-        "13-custom-parameter-type" => (b13::register, b13::state),
-        "14-stateless-steps" => (b14::register, b14::state),
-        "15-custom-parameter-format" => (b15::register, b15::state),
+        "01-roman-numerals" => bundle!(b01),
+        "02-context-isolation" => bundle!(b02),
+        "03-expected-failure" => bundle!(b03),
+        "04-tables-and-docstrings" => bundle!(b04),
+        "05-ambiguous-match" => bundle!(b05),
+        "06-doc-string-mismatch" => bundle!(b06),
+        "07-row-check-mismatch" => bundle!(b07),
+        "08-string-capture" => bundle!(b08),
+        "09-expected-message-mismatch" => bundle!(b09),
+        "10-error-fence-without-step" => bundle!(b10),
+        "11-emoji-offsets" => bundle!(b11),
+        "12-combining-marks" => bundle!(b12),
+        "13-custom-parameter-type" => bundle!(b13),
+        "14-stateless-steps" => bundle!(b14),
+        "15-custom-parameter-format" => bundle!(b15),
         other => panic!("no Rust step fixture for bundle {other}"),
     }
 }
@@ -105,10 +119,7 @@ fn registry_matches_golden() {
     let mut fails = Vec::new();
     for dir in bundle_dirs() {
         let name = name_of(&dir);
-        let (register, _) = fixture(&name);
-        let mut s = Steps::from_registry(create_registry());
-        register(&mut s);
-        let registry = s.into_registry();
+        let (registry, _) = fixture(&name);
         let actual = canonical_stringify(&to_registry_artifact(&registry));
         if actual != golden(&dir, "registry.json") {
             fails.push(name);
@@ -122,10 +133,7 @@ fn plan_matches_golden() {
     let mut fails = Vec::new();
     for dir in bundle_dirs() {
         let name = name_of(&dir);
-        let (register, _) = fixture(&name);
-        let mut s = Steps::from_registry(create_registry());
-        register(&mut s);
-        let registry = s.into_registry();
+        let (registry, _) = fixture(&name);
         let source = fs::read_to_string(dir.join("example.md")).unwrap();
         let doc = parse("example.md", &source);
         let execution = plan(&doc, &registry);
@@ -142,10 +150,7 @@ fn trace_matches_golden() {
     let mut fails = Vec::new();
     for dir in bundle_dirs() {
         let name = name_of(&dir);
-        let (register, state) = fixture(&name);
-        let mut s = Steps::from_registry(create_registry());
-        register(&mut s);
-        let registry = s.into_registry();
+        let (registry, state) = fixture(&name);
         let source = fs::read_to_string(dir.join("example.md")).unwrap();
         let doc = parse("example.md", &source);
         let artifacts = run_conformance(&doc, &registry, &|| state());


### PR DESCRIPTION
Applies to Rust the API minimisation just done for Go (per the porting skill's *keep the public API surface minimal*). A Rust step file no longer mentions `varar::Value` anywhere.

## What changed

- **`Steps<C>` is generic in the context type.** A step file declares its own `Ctx`; handlers take and return it, a stimulus returning the whole next `Ctx`. `varar-core` now treats the state as an opaque `Rc<dyn Any>` — threaded between a file's steps and replaced wholesale, but never compared, serialized, or inspected, so **no golden changes**.
- **Slots arrive as the handler's own Rust types**, via `FromSlot`/`ToSlot`. A sensor returns one value per slot — `(n, n * n)` where TypeScript writes `[n, n * n]`. A sensor that asserts for itself returns `()`, the opt-out a greedy `{word}` capture needs.
- **`param` is declared in terms of the type it produces**, so `{date}` yields a `Date` directly instead of a map the handler unpacks.

```rust
#[derive(Clone, Default)]
pub struct Ctx { pub result: String }

pub fn register(s: &mut Steps<Ctx>) {
    s.stimulus("I convert {int} to roman numerals", |_ctx: Ctx, n: i64| {
        Ok(Ctx { result: roman(n).unwrap_or_default().to_string() })
    });
    s.sensor("The square of {int} is {int}.", |_ctx: Ctx, n: i64, _sq: i64| Ok((n, n * n)));
}
```

## Compile-time, not run-time

Unlike Go's reflective equivalent, all of this is checked by the compiler: a wrong arity, an unreadable slot type, or a sensor whose results don't match its slots is a build error.

## What `Value` is still for

It stays exported purely as the escape hatch — a slot with no natural Rust spelling, and the type you name when implementing `FromSlot`/`ToSlot` for a domain type. Rust has no reflection, so unlike Go (where a plain struct maps automatically) a domain type states its mapping once.

## Verification

All 15 fixtures and the sample project rewritten. The three conformance artifacts reproduce byte-for-byte, the 30 sample specs pass, `make rust` is green (41 suites, fmt + clippy `-D warnings` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)